### PR TITLE
kbk50 naar schaal 20.000 ipv 12.500 

### DIFF
--- a/bgt.map
+++ b/bgt.map
@@ -1209,9 +1209,10 @@ MAP
      CLASS
        STYLE
          ANTIALIAS      true
-         COLOR          220 220 255
-         OUTLINECOLOR   160 160 205
+         COLOR         "#E5E3DE"
+         OUTLINECOLOR  "#C9C7C2"
          WIDTH          1
+         OPACITY        60
        END
      END
 
@@ -1238,14 +1239,14 @@ MAP
      CLASS
        STYLE
          ANTIALIAS      true
-         COLOR          220 220 255
-         OUTLINECOLOR   160 160 205
+         COLOR         "#E5E3DE"
+         OUTLINECOLOR  "#C9C7C2"
          WIDTH          1
          OPACITY        60
        END
      END
 
-   END
+  END
 
 
 

--- a/kbk10.map
+++ b/kbk10.map
@@ -78,7 +78,7 @@ MAP
   LAYER
     NAME                    WDL_breed_water
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WDL_breed_water\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -87,7 +87,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#95c6d5"
@@ -100,7 +100,7 @@ MAP
   LAYER
     NAME                    WDL_haven
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WDL_haven\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -109,7 +109,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#95c6d5"
@@ -122,7 +122,7 @@ MAP
   LAYER
     NAME                    TRN_aanlegsteiger
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_aanlegsteiger\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -131,7 +131,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         WIDTH 1
@@ -148,7 +148,7 @@ MAP
   LAYER
     NAME                    TRN_basaltblokken_steenglooiing
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_basaltblokken_steenglooiing\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -157,7 +157,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#f6f6f4"
@@ -170,7 +170,7 @@ MAP
   LAYER
     NAME                    TRN_grasland
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_grasland\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -179,7 +179,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#dceacf"
@@ -192,7 +192,7 @@ MAP
   LAYER
     NAME                    TRN_akkerland
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_akkerland\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -201,7 +201,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#dceacf"
@@ -214,7 +214,7 @@ MAP
   LAYER
     NAME                    TRN_overig
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_overig\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -223,7 +223,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#f2ecee"
@@ -236,7 +236,7 @@ MAP
   LAYER
     NAME                    TRN_bedrijfsterrein
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_bedrijfsterrein\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -245,7 +245,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#f6f6f4"
@@ -258,7 +258,7 @@ MAP
   LAYER
     NAME                    TRN_openbaar_groen
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_openbaar_groen\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -267,7 +267,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#f9f9e7"
@@ -280,7 +280,7 @@ MAP
   LAYER
     NAME                    TRN_zand
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_zand\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -289,7 +289,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#fbf0de"
@@ -302,7 +302,7 @@ MAP
   LAYER
     NAME                    WGL_startbaan_landingsbaan
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WGL_startbaan_landingsbaan\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -311,7 +311,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#dddcda"
@@ -324,7 +324,7 @@ MAP
   LAYER
     NAME                    TRN_spoorbaanlichaam
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_spoorbaanlichaam\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -333,7 +333,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#dddcda"
@@ -346,7 +346,7 @@ MAP
   LAYER
     NAME                    TRN_bos-loofbos
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_bos-loofbos\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -355,7 +355,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#cbe0b8"
@@ -368,7 +368,7 @@ MAP
   LAYER
     NAME                    TRN_bos-naaldbos
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_bos-naaldbos\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -377,7 +377,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#cbe0b8"
@@ -390,7 +390,7 @@ MAP
   LAYER
     NAME                    TRN_bos-gemengd_bos
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_bos-gemengd_bos\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -399,7 +399,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#cbe0b8"
@@ -412,7 +412,7 @@ MAP
   LAYER
     NAME                    TRN_bos-griend
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_bos-griend\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -421,7 +421,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#cbe0b8"
@@ -434,7 +434,7 @@ MAP
   LAYER
     NAME                    TRN_boomgaard
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_boomgaard\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -443,7 +443,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#d4e5c4"
@@ -456,7 +456,7 @@ MAP
   LAYER
     NAME                    TRN_boomkwekerij
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_boomkwekerij\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -465,7 +465,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#d4e5c4"
@@ -478,7 +478,7 @@ MAP
   LAYER
     NAME                    TRN_dodenakker
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_dodenakker\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -487,7 +487,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#d4e5c4"
@@ -500,7 +500,7 @@ MAP
   LAYER
     NAME                    TRN_dodenakker_met_bos
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_dodenakker_met_bos\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -509,7 +509,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#d4e5c4"
@@ -522,7 +522,7 @@ MAP
   LAYER
     NAME                    TRN_fruitkwekerij
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"TRN_fruitkwekerij\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -531,7 +531,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#d4e5c4"
@@ -544,7 +544,7 @@ MAP
   LAYER
     NAME                    GBW_overdekt
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"GBW_overdekt\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -565,7 +565,7 @@ MAP
   LAYER
     NAME                    GBW_gebouw
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"GBW_gebouw\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -574,7 +574,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#e5e3de"
@@ -591,7 +591,7 @@ MAP
   LAYER
     NAME                    GBW_hoogbouw
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"GBW_hoogbouw\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -600,7 +600,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#e6e5e0"
@@ -686,7 +686,7 @@ MAP
   LAYER
     NAME                    WDL_waterbassin
     GROUP                   "vlakken"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WDL_waterbassin\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -695,7 +695,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         COLOR "#95c6d5"
@@ -708,7 +708,7 @@ MAP
   LAYER
     NAME                    WDL_smal_water_3_tot_6m
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WDL_smal_water_3_tot_6m\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -717,7 +717,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         WIDTH 2
@@ -733,7 +733,7 @@ MAP
   LAYER
     NAME                    WDL_smal_water_tot_3m
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WDL_smal_water_tot_3m\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -742,7 +742,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         WIDTH 1
@@ -758,7 +758,7 @@ MAP
   LAYER
     NAME                    KRT_tunnelcontour
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"KRT_tunnelcontour\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -767,7 +767,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM           3500
       STYLE
         OPACITY        30
@@ -784,7 +784,7 @@ MAP
   LAYER
     NAME                    IRT_aanlegsteiger_smal
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"IRT_aanlegsteiger_smal\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -793,7 +793,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         WIDTH 1
@@ -809,7 +809,7 @@ MAP
   LAYER
     NAME                    WGL_smalle_weg-case
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WGL_smalle_weg\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -818,7 +818,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         WIDTH 3
@@ -834,7 +834,7 @@ MAP
   LAYER
     NAME                    WGL_smalle_weg-fill
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WGL_smalle_weg\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -843,7 +843,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 3500
       STYLE
         WIDTH 2
@@ -859,7 +859,7 @@ MAP
   LAYER
     NAME                    SBL_metro_overdekt_case
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_metro_overdekt\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -868,7 +868,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 8000
       STYLE
         WIDTH 6
@@ -904,7 +904,7 @@ MAP
   LAYER
     NAME                    SBL_metro_overdekt_line
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_metro_overdekt\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -913,7 +913,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 8000
       STYLE
         WIDTH 3
@@ -976,7 +976,7 @@ MAP
   LAYER
     NAME                    SBL_trein_overdekt_1sp-line
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
 	  MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_overdekt_1sp\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -985,7 +985,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 8000
       STYLE
         WIDTH 2.5
@@ -1019,7 +1019,7 @@ MAP
   LAYER
     NAME                    SBL_trein_overdekt_nsp-line
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
 	  MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_overdekt_nsp\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1028,7 +1028,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
 	    MINSCALEDENOM 8000
       STYLE
         WIDTH 2.5
@@ -1062,7 +1062,7 @@ MAP
   LAYER
     NAME                    SBL_trein_overdekt_1sp-dash
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_overdekt_1sp\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1071,7 +1071,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
 	    MINSCALEDENOM 8000
       STYLE
         WIDTH 1.5
@@ -1105,7 +1105,7 @@ MAP
   LAYER
     NAME                    SBL_trein_overdekt_nsp-dash
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_overdekt_nsp\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1114,7 +1114,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
 	   MINSCALEDENOM 8000
       STYLE
         WIDTH 1.5
@@ -1148,7 +1148,7 @@ MAP
   LAYER
     NAME                    SBL_metro_nietoverdekt_1sp_case
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_metro_nietoverdekt_1sp\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1157,7 +1157,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 8000
       STYLE
         WIDTH 2.5
@@ -1183,7 +1183,7 @@ MAP
   LAYER
     NAME                    SBL_metro_nietoverdekt_1sp_dash
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_metro_nietoverdekt_1sp\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1192,7 +1192,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 8000
       STYLE
         WIDTH 1.5
@@ -1226,7 +1226,7 @@ MAP
   LAYER
     NAME                    SBL_metro_nietoverdekt_nsp_case
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_metro_nietoverdekt_nsp\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1235,7 +1235,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 8000
       STYLE
         WIDTH 2.5
@@ -1261,7 +1261,7 @@ MAP
   LAYER
     NAME                    SBL_metro_nietoverdekt_nsp_dash
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_metro_nietoverdekt_nsp\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1270,7 +1270,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 8000
       STYLE
         WIDTH 1.5
@@ -1329,7 +1329,7 @@ MAP
   LAYER
     NAME                    SBL_trein_ongeelektrificeerd-line
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
 	  MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_ongeelektrificeerd\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1338,7 +1338,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
 	    MINSCALEDENOM 8000
       STYLE
         WIDTH 2.5
@@ -1364,7 +1364,7 @@ MAP
   LAYER
     NAME                    SBL_trein_ongeelektrificeerd-dash
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
 	  MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_ongeelektrificeerd\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1373,7 +1373,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
 	    MINSCALEDENOM 8000
       STYLE
         WIDTH 1.5
@@ -1407,7 +1407,7 @@ MAP
   LAYER
     NAME                    SBL_trein_nietoverdekt_1sp-line
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_nietoverdekt_1sp\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1416,7 +1416,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 8000
       STYLE
         WIDTH 2.5
@@ -1442,7 +1442,7 @@ MAP
   LAYER
     NAME                    SBL_trein_nietoverdekt_nsp-line
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_nietoverdekt_nsp\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1451,7 +1451,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 8000
       STYLE
         WIDTH 2.5
@@ -1477,7 +1477,7 @@ MAP
   LAYER
     NAME                    SBL_trein_nietoverdekt_1sp-dash
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
 	  MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_nietoverdekt_1sp\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1486,7 +1486,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
 	    MINSCALEDENOM 8000
       STYLE
         WIDTH 1.5
@@ -1500,7 +1500,7 @@ MAP
       END
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
 	    MINSCALEDENOM 3500
       STYLE
         WIDTH 2
@@ -1521,7 +1521,7 @@ MAP
   LAYER
     NAME                    SBL_trein_nietoverdekt_nsp-dash
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
 	  MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"SBL_trein_nietoverdekt_nsp\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1530,7 +1530,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
 	    MINSCALEDENOM 8000
       STYLE
         WIDTH 1.5
@@ -1544,7 +1544,7 @@ MAP
       END
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
 	    MINSCALEDENOM 3500
       STYLE
         WIDTH 2
@@ -1564,7 +1564,7 @@ MAP
   LAYER
     NAME                    WGL_autosnelweg_lijn-case
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WGL_hartlijn\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1575,7 +1575,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 8000
       STYLE
         WIDTH 5
@@ -1601,7 +1601,7 @@ MAP
   LAYER
     NAME                    WGL_autosnelweg_lijn-fill
     GROUP                   "lijnen"
-    MAXSCALEDENOM           12500
+    MAXSCALEDENOM           20000
     MINSCALEDENOM           3500
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk10.\"WGL_hartlijn\" USING srid=28992 USING UNIQUE ogc_fid"
@@ -1612,7 +1612,7 @@ MAP
       "init=epsg:28992"
     END
     CLASS
-      MAXSCALEDENOM 12500
+      MAXSCALEDENOM 20000
       MINSCALEDENOM 8000
       STYLE
       WIDTH 3

--- a/kbk50.map
+++ b/kbk50.map
@@ -67,7 +67,7 @@ MAP
     NAME                    WDL_wateroppervlak
     GROUP                   "vlakken"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WDL_wateroppervlak\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE POLYGON
@@ -76,7 +76,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         COLOR               "#95c6d5"
       END 
@@ -89,7 +89,7 @@ MAP
     NAME                    TRN_agrarisch
     GROUP                   "vlakken"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"TRN_agrarisch\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -98,7 +98,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         COLOR               "#dceacf"
       END
@@ -111,7 +111,7 @@ MAP
     NAME                    TRN_overig
     GROUP                   "vlakken"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"TRN_overig\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -120,7 +120,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         COLOR               "#f6f6f4"
       END
@@ -133,7 +133,7 @@ MAP
     NAME                    TRN_bedrijfsterrein_dienstverlening
     GROUP                   "vlakken"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"TRN_bedrijfsterrein_dienstverlening\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -142,7 +142,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         COLOR               "#d3d2cf"
       END
@@ -161,7 +161,7 @@ MAP
     NAME                    TRN_bos_groen_sport
     GROUP                   "vlakken"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"TRN_bos_groen_sport\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE POLYGON
@@ -170,7 +170,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         COLOR "#cbe0b8"
       END
@@ -183,7 +183,7 @@ MAP
     NAME                    TRN_zand
     GROUP                   "vlakken"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"TRN_zand\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -192,7 +192,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         COLOR               "#fbf0de"
       END
@@ -205,7 +205,7 @@ MAP
     NAME                    GBW_bebouwing
     GROUP                   "vlakken"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"GBW_bebouwing\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE POLYGON
@@ -214,14 +214,14 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 300000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         COLOR "#e5e3de"
       END
     END
     CLASS
       MAXSCALEDENOM 50000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 0.7
         OUTLINECOLOR "#e5e3de"
@@ -237,7 +237,7 @@ MAP
     NAME                    GBW_kassen
     GROUP                   "vlakken"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"GBW_kassen\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    POLYGON
@@ -246,7 +246,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         COLOR "#e3dbd3"
       END
@@ -259,7 +259,7 @@ MAP
     NAME                    WDL_brede_waterloop
     GROUP                   "lijnen"
     MAXSCALEDENOM           50000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WDL_brede_waterloop\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -268,7 +268,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM           50000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         WIDTH 0.1
         OUTLINECOLOR "#95c6d5"
@@ -284,7 +284,7 @@ MAP
     NAME                    WDL_smalle_waterloop
     GROUP                   "lijnen"
     MAXSCALEDENOM           50000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WDL_smalle_waterloop\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -293,7 +293,7 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 50000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 0.2
         COLOR "#95c6d5"
@@ -309,7 +309,7 @@ MAP
     NAME                    WGL_straat_in_tunnel
     GROUP                   "lijnen"
     MAXSCALEDENOM           75000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_straat_in_tunnel\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -319,7 +319,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 25000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 2
         PATTERN
@@ -354,7 +354,7 @@ MAP
     NAME                    WGL_hoofdweg_in_tunnel-case
     GROUP                   "lijnen"
     MAXSCALEDENOM           100000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_hoofdweg_in_tunnel\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -364,7 +364,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 25000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 4
         PATTERN
@@ -414,7 +414,7 @@ MAP
     NAME                    WGL_regionale_weg_in_tunnel-case
     GROUP                   "lijnen"
     MAXSCALEDENOM           100000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_regionale_weg_in_tunnel\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -424,7 +424,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 25000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 5
         PATTERN
@@ -474,7 +474,7 @@ MAP
     NAME                    WGL_autosnelweg_in_tunnel-case
     GROUP                   "lijnen"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_autosnelweg_in_tunnel\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -484,7 +484,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 50000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 2
         PATTERN
@@ -519,7 +519,7 @@ MAP
     NAME                    WGL_regionale_weg_in_tunnel-fill
     GROUP                   "lijnen"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_regionale_weg_in_tunnel\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -529,7 +529,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 50000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 3
         COLOR "#ffffff"
@@ -556,7 +556,7 @@ MAP
     NAME                    WGL_autosnelweg_in_tunnel-fill
     GROUP                   "lijnen"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_autosnelweg_in_tunnel\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -566,7 +566,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 25000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 3
         COLOR "#fefafaf0"
@@ -626,7 +626,7 @@ MAP
     NAME                    WGL_straat-case
     GROUP                   "lijnen"
     MAXSCALEDENOM           75000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_straat\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -636,7 +636,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 25000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 3
         COLOR "#c9c7c2"
@@ -663,7 +663,7 @@ MAP
     NAME                    WGL_hoofdweg-case
     GROUP                   "lijnen"
     MAXSCALEDENOM           100000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_hoofdweg\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -673,7 +673,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 25000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 6
         COLOR "#acacac"
@@ -711,7 +711,7 @@ MAP
     NAME                    WGL_regionale_weg-case
     GROUP                   "lijnen"
     MAXSCALEDENOM           100000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_regionale_weg\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -721,7 +721,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 25000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 4
         COLOR "#acacac"
@@ -759,7 +759,7 @@ MAP
     NAME                    WGL_straat-fill
     GROUP                   "lijnen"
     MAXSCALEDENOM           75000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_straat\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -769,7 +769,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 25000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 2
         COLOR "#ffffff"
@@ -796,7 +796,7 @@ MAP
     NAME                    WGL_hoofdweg-fill
     GROUP                   "lijnen"
     MAXSCALEDENOM           100000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_hoofdweg\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -806,7 +806,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 25000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 5
         COLOR "#ffffff"
@@ -844,7 +844,7 @@ MAP
     NAME                    WGL_regionale_weg-fill
     GROUP                   "lijnen"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_regionale_weg\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -854,7 +854,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 25000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 3
         COLOR "#ffffff"
@@ -915,7 +915,7 @@ MAP
     NAME                    SBL_metro_sneltram_in_tunnel_case
     GROUP                   "lijnen"
     MAXSCALEDENOM           25000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"SBL_metro_sneltram_in_tunnel\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -924,7 +924,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM           25000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         WIDTH 4
         # INITIALGAP 2
@@ -945,7 +945,7 @@ MAP
     NAME                    SBL_metro_sneltram_in_tunnel_line
     GROUP                   "lijnen"
     MAXSCALEDENOM           25000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"SBL_metro_sneltram_in_tunnel\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -954,7 +954,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM           25000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         WIDTH 2
         PATTERN 8 8
@@ -972,7 +972,7 @@ MAP
     NAME                    SBL_trein_in_tunnel_case
     GROUP                   "lijnen"
     MAXSCALEDENOM           100000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"SBL_trein_in_tunnel\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -981,7 +981,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM          100000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         WIDTH 2
         COLOR "#9d9d9d"
@@ -1001,7 +1001,7 @@ MAP
     NAME                    SBL_trein_in_tunnel_line
     GROUP                   "lijnen"
     MAXSCALEDENOM           100000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"SBL_trein_in_tunnel\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -1010,7 +1010,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM          100000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         WIDTH 1.5
         COLOR "#ffffff"
@@ -1030,7 +1030,7 @@ MAP
     NAME                    SBL_metro_sneltram-case
     GROUP                   "lijnen"
     MAXSCALEDENOM           25000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"SBL_metro_sneltram\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1039,7 +1039,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM           25000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         WIDTH 3
         COLOR "#fc7f7f"
@@ -1055,7 +1055,7 @@ MAP
     NAME                    SBL_metro_sneltram-line
     GROUP                   "lijnen"
     MAXSCALEDENOM           25000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"SBL_metro_sneltram\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1064,7 +1064,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM          25000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         WIDTH 2
         COLOR "#ffffff"
@@ -1084,7 +1084,7 @@ MAP
     NAME                    SBL_trein_ongeelektrificeerd-line
     GROUP                   "lijnen"
     MAXSCALEDENOM           25000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"SBL_trein_ongeelektrificeerd\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1093,7 +1093,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM           25000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         WIDTH 3
         COLOR "#9d9d9d"
@@ -1109,7 +1109,7 @@ MAP
     NAME                    SBL_trein_ongeelektrificeerd-dash
     GROUP                   "lijnen"
     MAXSCALEDENOM           25000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"SBL_trein_ongeelektrificeerd\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -1118,7 +1118,7 @@ MAP
     END
     CLASS
     MAXSCALEDENOM           25000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
       STYLE
         WIDTH 1.5
         PATTERN
@@ -1138,7 +1138,7 @@ MAP
     NAME                    SBL_trein-line
     GROUP                   "lijnen"
     MAXSCALEDENOM           100000
-    MINSCALEDENOM            12500
+    MINSCALEDENOM            20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"SBL_trein\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -1148,7 +1148,7 @@ MAP
     CLASS
       # Zoom{=14}
       MAXSCALEDENOM 50000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 3
         COLOR "#9d9d9d"
@@ -1175,7 +1175,7 @@ MAP
     NAME                    SBL_trein-dash
     GROUP                   "lijnen"
     MAXSCALEDENOM           100000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"SBL_trein\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -1184,7 +1184,7 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 50000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 1.5
         PATTERN
@@ -1218,7 +1218,7 @@ MAP
     NAME                    WGL_autosnelweg-case
     GROUP                   "lijnen"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_autosnelweg\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE LINE
@@ -1228,7 +1228,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 25000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 7
         COLOR "#fa0000"
@@ -1277,7 +1277,7 @@ MAP
     NAME                    WGL_autosnelweg-fill
     GROUP                   "lijnen"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_autosnelweg\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1287,7 +1287,7 @@ MAP
     CLASS
       # Zoom{=15}
       MAXSCALEDENOM 25000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 5
         COLOR "#fefafaf0"
@@ -1336,7 +1336,7 @@ MAP
     NAME                    WGL_autosnelweg-centerline
     GROUP                   "lijnen"
     MAXSCALEDENOM           300000
-    MINSCALEDENOM           12500
+    MINSCALEDENOM           20000
     INCLUDE                 "connection_basiskaart.inc"
     DATA                    "geom FROM kbk50.\"WGL_autosnelweg\" USING srid=28992 USING UNIQUE ogc_fid"
     TYPE                    LINE
@@ -1345,7 +1345,7 @@ MAP
     END
     CLASS
       MAXSCALEDENOM 50000
-      MINSCALEDENOM 12500
+      MINSCALEDENOM 20000
       STYLE
         WIDTH 0.4
         COLOR "#fa0000"

--- a/sld/kbk10_light.xml
+++ b/sld/kbk10_light.xml
@@ -6,7 +6,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#B2CBD9</CssParameter>
@@ -22,7 +22,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#B2CBD9</CssParameter>
@@ -38,7 +38,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F6F6F4</CssParameter>
@@ -58,7 +58,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F6F6F4</CssParameter>
@@ -74,7 +74,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#E5EBD8</CssParameter>
@@ -90,7 +90,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#E5EBD8</CssParameter>
@@ -106,7 +106,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F5F4F2</CssParameter>
@@ -122,7 +122,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F5F4F2</CssParameter>
@@ -138,7 +138,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D2E3BA</CssParameter>
@@ -154,7 +154,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#E5EBD8</CssParameter>
@@ -170,7 +170,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#DEDCD9</CssParameter>
@@ -186,7 +186,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D9D9D4</CssParameter>
@@ -202,7 +202,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D2E3BA</CssParameter>
@@ -218,7 +218,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D2E3BA</CssParameter>
@@ -234,7 +234,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D2E3BA</CssParameter>
@@ -250,7 +250,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D2E3BA</CssParameter>
@@ -266,7 +266,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D2E3BA</CssParameter>
@@ -282,7 +282,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D2E3BA</CssParameter>
@@ -298,7 +298,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#E5EBD8</CssParameter>
@@ -314,7 +314,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D2E3BA</CssParameter>
@@ -330,7 +330,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D2E3BA</CssParameter>
@@ -346,7 +346,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D9D9D4</CssParameter>
@@ -362,7 +362,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D9D9D4</CssParameter>
@@ -384,7 +384,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D9D9D4</CssParameter>
@@ -406,7 +406,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D9D9D4</CssParameter>
@@ -455,7 +455,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#B2CBD9</CssParameter>
@@ -471,7 +471,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B2CBD9</CssParameter>
@@ -488,7 +488,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B2CBD9</CssParameter>
@@ -505,7 +505,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FFFFFF</CssParameter>
@@ -523,7 +523,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -540,7 +540,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -557,7 +557,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -574,7 +574,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -590,7 +590,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -624,7 +624,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -640,7 +640,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -656,7 +656,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -673,7 +673,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -690,7 +690,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -706,7 +706,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -723,7 +723,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -739,7 +739,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -773,7 +773,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -789,7 +789,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -806,7 +806,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -822,7 +822,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -838,7 +838,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -855,7 +855,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -878,7 +878,7 @@
             </ogc:PropertyIsEqualTo>
           </ogc:Filter>
           <MinScaleDenominator>8000</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -917,7 +917,7 @@
             </ogc:PropertyIsEqualTo>
           </ogc:Filter>
           <MinScaleDenominator>8000</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#EAEAAE</CssParameter>

--- a/sld/kbk10_zw.xml
+++ b/sld/kbk10_zw.xml
@@ -6,7 +6,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#BEBEBE</CssParameter>
@@ -22,7 +22,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#BEBEBE</CssParameter>
@@ -38,7 +38,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F6F6F4</CssParameter>
@@ -58,7 +58,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F6F6F4</CssParameter>
@@ -74,7 +74,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F5F4F2</CssParameter>
@@ -90,7 +90,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F5F4F2</CssParameter>
@@ -106,7 +106,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F0F0F0</CssParameter>
@@ -122,7 +122,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F0F0F0</CssParameter>
@@ -138,7 +138,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#EDECE9</CssParameter>
@@ -154,7 +154,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#FBFBFB</CssParameter>
@@ -170,7 +170,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#DEDCD9</CssParameter>
@@ -186,7 +186,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F5F4F2</CssParameter>
@@ -202,7 +202,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#DCDCDC</CssParameter>
@@ -218,7 +218,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#DCDCDC</CssParameter>
@@ -234,7 +234,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#DCDCDC</CssParameter>
@@ -250,7 +250,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#DCDCDC</CssParameter>
@@ -266,7 +266,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#DCDCDC</CssParameter>
@@ -282,7 +282,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#DCDCDC</CssParameter>
@@ -298,7 +298,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#DCDCDC</CssParameter>
@@ -314,7 +314,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#DCDCDC</CssParameter>
@@ -330,7 +330,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#DCDCDC</CssParameter>
@@ -346,7 +346,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#EBEAE6</CssParameter>
@@ -362,7 +362,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#E4E3DF</CssParameter>
@@ -384,7 +384,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#E6E5E0</CssParameter>
@@ -406,7 +406,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#E8E8E8</CssParameter>
@@ -455,7 +455,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#BEBEBE</CssParameter>
@@ -471,7 +471,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BEBEBE</CssParameter>
@@ -488,7 +488,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BEBEBE</CssParameter>
@@ -505,7 +505,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FFFFFF</CssParameter>
@@ -523,7 +523,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -540,7 +540,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -557,7 +557,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FFFFFF</CssParameter>
@@ -574,7 +574,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -590,7 +590,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -624,7 +624,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -641,7 +641,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -658,7 +658,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -674,7 +674,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -690,7 +690,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -706,7 +706,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -723,7 +723,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -739,7 +739,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -773,7 +773,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -789,7 +789,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -806,7 +806,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -822,7 +822,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>
@@ -838,7 +838,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -855,7 +855,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -878,7 +878,7 @@
             </ogc:PropertyIsEqualTo>
           </ogc:Filter>
           <MinScaleDenominator>8000</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#787878</CssParameter>
@@ -917,7 +917,7 @@
             </ogc:PropertyIsEqualTo>
           </ogc:Filter>
           <MinScaleDenominator>8000</MinScaleDenominator>
-          <MaxScaleDenominator>12500</MaxScaleDenominator>
+          <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#DFDFDF</CssParameter>

--- a/sld/kbk50_light.xml
+++ b/sld/kbk50_light.xml
@@ -5,7 +5,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -21,7 +21,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -37,7 +37,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -53,7 +53,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -75,7 +75,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -91,7 +91,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -107,7 +107,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>50000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -136,7 +136,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -152,7 +152,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -179,7 +179,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>50000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -196,7 +196,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -225,7 +225,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -265,7 +265,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -305,7 +305,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -366,7 +366,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -413,7 +413,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -460,7 +460,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -487,7 +487,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -524,7 +524,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -551,7 +551,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -578,7 +578,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -615,7 +615,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -652,7 +652,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -669,7 +669,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -686,7 +686,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>100000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -703,7 +703,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>100000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -720,7 +720,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -737,7 +737,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -754,7 +754,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -771,7 +771,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -788,7 +788,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>100000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -805,7 +805,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>100000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -822,7 +822,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -869,7 +869,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -916,7 +916,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>

--- a/sld/kbk50_zw.xml
+++ b/sld/kbk50_zw.xml
@@ -5,7 +5,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -21,7 +21,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -37,7 +37,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -53,7 +53,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -73,7 +73,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -89,7 +89,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -105,7 +105,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>50000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -134,7 +134,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -150,7 +150,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>50000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -167,7 +167,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>50000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -184,7 +184,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -213,7 +213,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -253,7 +253,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -293,7 +293,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -354,7 +354,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -401,7 +401,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -448,7 +448,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -475,7 +475,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -512,7 +512,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -539,7 +539,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -566,7 +566,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -603,7 +603,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -650,7 +650,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -667,7 +667,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -684,7 +684,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>100000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -701,7 +701,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>100000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -718,7 +718,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -734,7 +734,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -751,7 +751,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -768,7 +768,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -785,7 +785,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>100000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -802,7 +802,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>100000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -819,7 +819,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -866,7 +866,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>25000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -913,7 +913,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>12500</MinScaleDenominator>
+          <MinScaleDenominator>20000</MinScaleDenominator>
           <MaxScaleDenominator>300000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>

--- a/topografie.map
+++ b/topografie.map
@@ -30,7 +30,7 @@ MAP
         CONNECTION              "MAP_URL_REPLACE/maps/kbk50?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           400000
-        MINSCALEDENOM           12500
+        MINSCALEDENOM           20000
         METADATA
             "wms_title"           "kbk50"
             "wms_group_title"     "basiskaart"
@@ -56,7 +56,7 @@ MAP
         CONNECTION              "MAP_URL_REPLACE/maps/kbk50?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           400000
-        MINSCALEDENOM           12500
+        MINSCALEDENOM           20000
         METADATA
             "wms_title"           "kbk50-light"
             "wms_group_title"     "basiskaart-light"
@@ -83,7 +83,7 @@ MAP
         CONNECTION              "MAP_URL_REPLACE/maps/kbk50?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           400000
-        MINSCALEDENOM           12500
+        MINSCALEDENOM           20000
         METADATA
             "wms_title"           "kbk50-zw"
             "wms_group_title"     "basiskaart-zw"
@@ -113,7 +113,7 @@ MAP
         TYPE                    RASTER
         CONNECTION              "MAP_URL_REPLACE/maps/kbk10?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
-        MAXSCALEDENOM           12500
+        MAXSCALEDENOM           20000
         MINSCALEDENOM           3500
         METADATA
             "wms_title"           "kbk10"
@@ -139,7 +139,7 @@ MAP
         TYPE                    RASTER
         CONNECTION              "MAP_URL_REPLACE/maps/kbk10?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
-        MAXSCALEDENOM           12500
+        MAXSCALEDENOM           20000
         MINSCALEDENOM           3500
         METADATA
             "wms_title"           "kbk10-light"
@@ -166,7 +166,7 @@ MAP
         TYPE                    RASTER
         CONNECTION              "MAP_URL_REPLACE/maps/kbk10?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
-        MAXSCALEDENOM           12500
+        MAXSCALEDENOM           20000
         MINSCALEDENOM           3500
         METADATA
             "wms_title"           "kbk10-zw"

--- a/topografie_wm.map
+++ b/topografie_wm.map
@@ -30,7 +30,7 @@ MAP
         CONNECTION              "MAP_URL_REPLACE/maps/kbk50?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           400000
-        MINSCALEDENOM           12500
+        MINSCALEDENOM           20000
         METADATA
             "wms_title"           "kbk50"
             "wms_group_title"     "basiskaart"
@@ -56,7 +56,7 @@ MAP
         CONNECTION              "MAP_URL_REPLACE/maps/kbk50?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           400000
-        MINSCALEDENOM           12500
+        MINSCALEDENOM           20000
         METADATA
             "wms_title"           "kbk50-light"
             "wms_group_title"     "basiskaart-light"
@@ -83,7 +83,7 @@ MAP
         CONNECTION              "MAP_URL_REPLACE/maps/kbk50?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           400000
-        MINSCALEDENOM           12500
+        MINSCALEDENOM           20000
         METADATA
             "wms_title"           "kbk50-zw"
             "wms_group_title"     "basiskaart-zw"
@@ -113,7 +113,7 @@ MAP
         TYPE                    RASTER
         CONNECTION              "MAP_URL_REPLACE/maps/kbk10?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
-        MAXSCALEDENOM           12500
+        MAXSCALEDENOM           20000
         MINSCALEDENOM           3500
         METADATA
             "wms_title"           "kbk10"
@@ -139,7 +139,7 @@ MAP
         TYPE                    RASTER
         CONNECTION              "MAP_URL_REPLACE/maps/kbk10?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
-        MAXSCALEDENOM           12500
+        MAXSCALEDENOM           20000
         MINSCALEDENOM           3500
         METADATA
             "wms_title"           "kbk10-light"
@@ -166,7 +166,7 @@ MAP
         TYPE                    RASTER
         CONNECTION              "MAP_URL_REPLACE/maps/kbk10?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
-        MAXSCALEDENOM           12500
+        MAXSCALEDENOM           20000
         MINSCALEDENOM           3500
         METADATA
             "wms_title"           "kbk10-zw"


### PR DESCRIPTION
Bij de webmercator tiling schema op zoom level 15 was de kbk50 te grof. Door de schaal naar 20.000 te zetten wordt de kbk10 getoond op zoom level 15. Bij de RD tiling schema verandert er niks. 
Hopelijk is dit niet een te grote aanslag op de tijd die het kost om de tegels te renderen?  

Daarnaast ook een kleur voorstel gedaan voor een andere kleur voor de BAG lig en staan plaatsen. 