### PR TITLE
Show only panoramas that are 'done'

### DIFF
--- a/panorama.map
+++ b/panorama.map
@@ -97,6 +97,8 @@ MAP
                           ST_Transform(!BOX!, 28992)
                         ) AND
                         '[%timestamp_after%, %timestamp_before%]'::tstzrange @> timestamp
+                        AND
+                        pano.status = 'done'
 
                       ) AS subquery
                     USING srid=4326 USING UNIQUE id"


### PR DESCRIPTION
Panoramas have a status, but only those that are normalized and blurred
are to be shown on the site. This works for API, but not yet for maps,
therefore behaviour on the site was not consistent between API and maps.
This fixes that.