### PR TITLE
Restore maplayer for panorama_recent WFS

### DIFF
--- a/panorama.map
+++ b/panorama.map
@@ -27,6 +27,154 @@ MAP
   #=============================================================================
 
   LAYER
+    NAME            "panorama_recent"
+    GROUP           "panorama opnamelocaties"
+    INCLUDE         "connection_panorama.inc"
+    DATA            "geometrie FROM (
+
+        SELECT
+            pp.id,
+            pp.pano_id as display,
+            pp.roll,
+            pp.pitch,
+            pp.heading,
+            pp.timestamp,
+            extract(year from pp.timestamp) as year,
+            pp._geolocation_2d AS geometrie,
+            'https://data.amsterdam.nl/panorama/' || pp.path || trim(trailing '.jpg' from pp.filename)
+            || '/equirectangular/panorama_8000.jpg' AS url,
+            'https://api.data.amsterdam.nl/panorama/recente_opnames/alle/' || pp.pano_id || '/' AS uri
+        FROM
+            panoramas_recent_all pp
+        WHERE
+            pp.geolocation IS NOT NULL
+
+
+    ) sq USING srid=4326 USING UNIQUE id"
+    TYPE            POINT
+    MINSCALEDENOM   100
+    MAXSCALEDENOM   10001
+    TEMPLATE        "fooOnlyForWMSGetFeatureInfo.html"
+
+    PROJECTION
+      "init=epsg:4326"
+    END
+
+    METADATA
+      "ows_title"           "panorama_recent"
+      "ows_group_title"     "recente panorama's"
+      "ows_abstract"        "recente panorama's"
+      "gml_featureid"       "id"
+      "gml_include_items"   "all"
+      "gml_types"           "auto"
+    END
+
+    COMPOSITE
+      OPACITY 70
+    END
+
+    CLASS
+      NAME "2018"
+      EXPRESSION ([year] eq 2018)
+      STYLE
+        MINSCALEDENOM   100
+        MAXSCALEDENOM   1001
+        SYMBOL         'stip'
+        SIZE           10
+        COLOR          0 160 60
+        OUTLINECOLOR   0 112 11
+        WIDTH          1
+      END
+      STYLE
+        MINSCALEDENOM   1002
+        MAXSCALEDENOM   4001
+        SYMBOL         'stip'
+        SIZE           6
+        COLOR          0 160 60
+        OUTLINECOLOR   0 112 11
+        WIDTH          1
+      END
+      STYLE
+        MINSCALEDENOM   4002
+        MAXSCALEDENOM   10001
+        SYMBOL         'stip'
+        SIZE           3
+        COLOR          0 160 60
+        OUTLINECOLOR   0 112 11
+        WIDTH          1
+      END
+    END
+
+    CLASS
+      NAME "2017"
+      EXPRESSION ([year] eq 2017)
+      STYLE
+        MINSCALEDENOM   100
+        MAXSCALEDENOM   1001
+        SYMBOL         'stip'
+        SIZE           10
+        COLOR          190 210 0
+        OUTLINECOLOR   137 161 0
+        WIDTH          1
+      END
+      STYLE
+        MINSCALEDENOM   1002
+        MAXSCALEDENOM   4001
+        SYMBOL         'stip'
+        SIZE           6
+        COLOR          190 210 0
+        OUTLINECOLOR   137 161 0
+        WIDTH          1
+      END
+      STYLE
+        MINSCALEDENOM   4002
+        MAXSCALEDENOM   10001
+        SYMBOL         'stip'
+        SIZE           3
+        COLOR          190 210 0
+        OUTLINECOLOR   137 161 0
+        WIDTH          1
+      END
+    END
+
+     CLASS
+      NAME "2016"
+      EXPRESSION ([year] eq 2016)
+
+      STYLE
+        MINSCALEDENOM   100
+        MAXSCALEDENOM   1001
+        SYMBOL         'stip'
+        SIZE           10
+        COLOR          233 227 130
+        OUTLINECOLOR   176 171 87
+        WIDTH          1
+      END
+      STYLE
+        MINSCALEDENOM   1002
+        MAXSCALEDENOM   4001
+        SYMBOL         'stip'
+        SIZE           6
+        COLOR          233 227 130
+        OUTLINECOLOR   176 171 87
+        WIDTH          1
+      END
+      STYLE
+        MINSCALEDENOM   4002
+        MAXSCALEDENOM   10001
+        SYMBOL         'stip'
+        SIZE           3
+        COLOR          233 227 130
+        OUTLINECOLOR   176 171 87
+        WIDTH          1
+      END
+    END
+
+  END
+
+  #-----------------------------------------------------------------------------
+
+  LAYER
     NAME            "panorama_new"
     GROUP           "panorama opnamelocaties"
     INCLUDE         "connection_panorama.inc"


### PR DESCRIPTION
As it turns out the maplayer panorama_new doesn't play nice with WFS.
That needs to be addressed. In the meantime recent panoramas are
accesable in the old layer. Because the geo-view has been removed, the
query from that view has been pasted into the data-source. Styling of
dots has been copied from panorama_new layer.