### PR TITLE
Changed evenementen map to reflect database changes

### DIFF
--- a/evenementen.map
+++ b/evenementen.map
@@ -27,11 +27,11 @@ MAP
     NAME                    "evenementen"
     GROUP                   "evenementen"
     PROJECTION
-      "init=epsg:28992"
+      "init=epsg:4326"
     END
 
     INCLUDE                 "connection_various_small_datasets.inc"
-    DATA                    "wkb_geometry FROM public.evenementen USING srid=28992 USING UNIQUE id"
+    DATA                    "geometry FROM public.evenementen USING srid=4326 USING UNIQUE id"
     TYPE                    POINT
     MINSCALEDENOM           10
     MAXSCALEDENOM           400000
@@ -39,16 +39,16 @@ MAP
 
     METADATA
       "wfs_title"           "Evenementen"
-      "wfs_srs"             "EPSG:28992"
+      "wfs_srs"             "EPSG:4326"
       "wfs_abstract"        "Evenementen Amsterdam"
       "wfs_enable_request"  "*"
-      "gml_featureid"       "ogc_fid"
+      "gml_featureid"       "evenement_id"
       "gml_include_items"   "all"
       "wms_title"           "Evenementen"
       "wms_enable_request"  "*"
       "wms_group_title"     "Evenementen"
       "wms_abstract"        "Evenementen Amsterdam"
-      "wms_srs"             "EPSG:28992"
+      "wms_srs"             "EPSG:4326"
       "wms_name"            "evenementen"
       "wms_format"          "image/png"
       "wms_server_version"  "1.1.1"


### PR DESCRIPTION
After changes in the import process the database-schema of evenementen
is slightly changed (other srid, some other fieldnames), this propagates
these changes.