### PR TITLE
Changed the projection of evenementen to follow DB change

### DIFF
--- a/evenementen.map
+++ b/evenementen.map
@@ -27,11 +27,11 @@ MAP
     NAME                    "evenementen"
     GROUP                   "evenementen"
     PROJECTION
-      "init=epsg:4326"
+      "init=epsg:28992"
     END
 
     INCLUDE                 "connection_various_small_datasets.inc"
-    DATA                    "geometry FROM public.evenementen USING srid=4326 USING UNIQUE id"
+    DATA                    "geometry FROM public.evenementen USING srid=28992 USING UNIQUE id"
     TYPE                    POINT
     MINSCALEDENOM           10
     MAXSCALEDENOM           400000
@@ -39,7 +39,7 @@ MAP
 
     METADATA
       "wfs_title"           "Evenementen"
-      "wfs_srs"             "EPSG:4326"
+      "wfs_srs"             "EPSG:28992"
       "wfs_abstract"        "Evenementen Amsterdam"
       "wfs_enable_request"  "*"
       "gml_featureid"       "evenement_id"
@@ -48,7 +48,7 @@ MAP
       "wms_enable_request"  "*"
       "wms_group_title"     "Evenementen"
       "wms_abstract"        "Evenementen Amsterdam"
-      "wms_srs"             "EPSG:4326"
+      "wms_srs"             "EPSG:28992"
       "wms_name"            "evenementen"
       "wms_format"          "image/png"
       "wms_server_version"  "1.1.1"


### PR DESCRIPTION
Geosearch expects the geometry column to be RD. Therefore the
srid of the geometry field of evenementen (and the default projection
at import) is changed.

This change follows the underlying data change