### PR TITLE
Choose existing symbol for kapvergunning

### DIFF
--- a/bekendmakingen.map
+++ b/bekendmakingen.map
@@ -306,7 +306,7 @@ MAP
 
       STYLE
         SIZE          17
-        SYMBOL        "cirkel_lichtrood"
+        SYMBOL        "cirkel_roze"
       END
 
       LABEL


### PR DESCRIPTION
The `cirkel_lichtrood` symbol is nog available, so whe choose an
existing one. Ideally new icons should be added, because this maps
exhausts the available list.