### PR TITLE
Update mpm_event config

### DIFF
--- a/docker/mpm_event.conf
+++ b/docker/mpm_event.conf
@@ -5,6 +5,6 @@
     MaxSpareThreads         75
     ThreadLimit             50
     ThreadsPerChild         10
-    MaxRequestWorkers      300
+    MaxRequestWorkers     3000
     MaxConnectionsPerChild   0
 </IfModule>


### PR DESCRIPTION
Tiling fails with message  `server reached MaxRequestWorkers setting, consider raising the MaxRequestWorkers setting`, MaxRequestWorkers bears relation to ServerLimit x ThreadsPerChild