### PR TITLE
Increase maxfeature limit WFS

### DIFF
--- a/header.inc
+++ b/header.inc
@@ -59,7 +59,7 @@
       "ows_feature_info_mime_type"   "application/json"
       "wms_format"                   "image/png"
       "wfs_encoding"                 "UTF-8"
-      "wfs_maxfeatures"              "500000"
+      "wfs_maxfeatures"              "750000"
       "wfs_getfeature_formatlist"    "gml,geojson,csv,shapezip,spatialzip"
 
       # verplicht om aan de OGC standaard te voldoen:


### PR DESCRIPTION
Cannot download all 519.250 verblijfsobjecten because of 500.000 limit and because there is no pagination implemented. This is a fix to be able to download all records for use in QGIS or separate file for further processing.