### PR TITLE
WFS laag naam in sync gebracht met Data Portaal

### DIFF
--- a/planologischezonesschiphol.map
+++ b/planologischezonesschiphol.map
@@ -323,8 +323,8 @@ MAP
     END
     
     METADATA
-      "ows_title"           "Schiphol - Planologische geluidszone"
-      "ows_abstract"        "Schiphol - Planologische geluidszone"
+      "ows_title"           "Schiphol - Ruimtelijke beperkingen"
+      "ows_abstract"        "Schiphol - Ruimtelijke beperkingen"
       "gml_featureid"       "ID"
       "gml_include_items"   "all"
     END


### PR DESCRIPTION
ows:title bijgewerkt zodat in QGIS dezelfde omschrijving wordt getoond als in het Data Portaal