### PR TITLE
Fix gml_featureid for container.

### DIFF
--- a/huishoudelijkafval.map
+++ b/huishoudelijkafval.map
@@ -104,7 +104,7 @@ MAP
       "wfs_srs"             "EPSG:28992"
       "wfs_abstract"        "Afvalcontainers Amsterdam"
       "wfs_enable_request"  "*"
-      "gml_featureid"       "containertype_naam"
+      "gml_featureid"       "container_id"
       "gml_include_items"   "all"
       "wms_title"           "Afvalcontainers"
       "wms_enable_request"  "*"


### PR DESCRIPTION
The feature_id for container was referring to a wrong field
leading to problem in WFS generation (entity ref issues
because of char '&' in the field that was used.