### PR TITLE
Added geometry type to enable MultiPolygon's in GeoJSON

### DIFF
--- a/bag.map
+++ b/bag.map
@@ -46,6 +46,7 @@ MAP
       "ows_abstract"        "BAG openbare ruimtes van de gemeente Amsterdam"
       "gml_featureid"       "ID"
       "gml_include_items"   "all"
+      "ows_geomtype"        "Geometry"
     END
 
     CLASSITEM "opr_type"


### PR DESCRIPTION
Setting a layer type overrides GeoJSON output making MultiPolygon be served as Polygons.

See discussion in https://lists.osgeo.org/pipermail/mapserver-users/2018-January/080439.html

Setting type to Geometry in metadata as suggested there to override this behaviour.