### PR TITLE
Spatie uit WFS layer naam gehaald

### DIFF
--- a/bag.map
+++ b/bag.map
@@ -279,7 +279,7 @@ MAP
 
 
   LAYER
-    NAME            "pand leeftijden"
+    NAME            "pandleeftijden"
     GROUP           "bouwjaar"
     INCLUDE         "connection_bag.inc"
     DATA            "geometrie FROM (SELECT


### PR DESCRIPTION
Schijnbaar kunnen niet alle clients om met een spatie in de WFS laag naam. Bij deze haal ik hem er dus uit.