### PR TITLE
[DS-255] Added the Regimes layers and sublayers 

### DIFF
--- a/parkeervakken.map
+++ b/parkeervakken.map
@@ -23,6 +23,412 @@ MAP
     END
   END
 
+ #=============================================================================
+  # LAYERS PARKEERVAKKEN REGIMES
+  # doel: tonen van 3 typen parkeervakken (de regimes: taxistandplaats, laden&lossen en kiss&ride) op basis van 4 standaardtijdvakken:
+  #   00:00 - 06:59
+  #   07:00 - 17:00
+  #   17.01 - 23.59
+  #   00:00 - 23:59
+  # bijzonderheden: per locatie, afhankelijk van een tijdsperiode, kan een parkeervak een bepaald regime aannemen. 
+  #                 Bijvoorbeeld Osdorplein is van 00:00 t/m 07:59 vrij van regime, van 08:00 t/m 20:00 een laad & los plek, en van 20:01 t/m 23:59 vrij van regime.
+  #                   
+  #=============================================================================
+
+  # Regime Taxistandplaats
+
+  LAYER
+    NAME            "tijdvakken_parkeren"
+    GROUP           "regimes"
+    INCLUDE         "connection_dataservices.inc"
+    DATA            "geom FROM public.parkeervakken_parkeervakken inner join (select begin_tijd, eind_tijd, parent_id, bord from parkeervakken_parkeervakken_regimes) pvr on ID = pvr.parent_id 
+                        inner join (
+                              select '00:00:00_06:59:00' as tijdvak
+                              union 
+                              select '07:00:00_17:00:00' 
+                              union 
+                              select '17:01:00_23:59:00' 
+                              union 
+                              select '00:00:00_23:59:00' 
+                              ) AS TV ON 
+                                cast(regexp_replace(tijdvak, '^([^_]+)_([^_]+)', '\1') as time)  < eind_tijd and cast(regexp_replace(tijdvak, '^([^_]+)_([^_]+)', '\2') as time)  > begin_tijd
+                                and e_type = 'E5' and bord = 'Taxistandplaats'
+                        USING srid=28992 USING UNIQUE id"
+    TYPE            POLYGON
+    MINSCALEDENOM   100
+    MAXSCALEDENOM   400000
+    TEMPLATE        "fooOnlyForWMSGetFeatureInfo.html"
+    PROJECTION      "init=epsg:28992"
+    END
+
+    VALIDATION
+      # %onderwerp% substitutions can only have letters, digits and underscore
+      'default_bord'  'all'
+      'bord'          '^[0-9a-zA-Z_,]{1,256}$'
+    END
+
+    METADATA
+      "wfs_title"           "Taxistandplaats"
+      "wfs_srs"             "EPSG:28992"
+      "wfs_abstract"        "Taxistandplaats Amsterdam"
+      "wfs_enable_request"  "*"
+      "gml_featureid"       "titel"
+      "gml_include_items"   "all"
+      "wms_title"           "Taxistandplaats"
+      "wms_enable_request"  "*"
+      "wms_group_title"     "Regimes"
+      "wms_abstract"        "Taxistandplaats Amsterdam"
+      "wms_srs"             "EPSG:28992"
+      "wms_name"            "Taxistandplaats"
+      "wms_format"          "image/png"
+      "wms_server_version"  "1.1.1"
+      "wms_extent"          "100000 450000 150000 500000"  
+    END
+
+    CLASS
+      NAME "tijdvak_00:00_06:59"
+      EXPRESSION ("[tijdvak]" eq "00:00:00_06:59:00")
+      
+      STYLE
+       ANTIALIAS    true
+       OUTLINECOLOR 160 0 120 #A00078
+       OPACITY      100
+       WIDTH        2
+      END   
+    
+      STYLE
+       ANTIALIAS    true
+       COLOR        160 0 120 #A00078
+       OPACITY      70
+       WIDTH        2
+      END   
+
+    END
+
+   CLASS
+      NAME "tijdvak_07:00_17:00"
+      EXPRESSION ("[tijdvak]" eq "07:00:00_17:00:00")
+      
+      STYLE
+       ANTIALIAS    true
+       OUTLINECOLOR 229 0 130 #E50082
+       OPACITY      100
+       WIDTH        2
+      END
+
+      STYLE
+       ANTIALIAS    true
+       COLOR        229 0 130 #E50082
+       OPACITY      70
+       WIDTH        2
+      END
+         
+    END
+
+    CLASS
+      NAME "tijdvak_17:01_23:59"
+      EXPRESSION ("[tijdvak]" eq "17:01:00_23:59:00")
+      
+      STYLE
+       ANTIALIAS    true
+       OUTLINECOLOR 255 145 0 #FF9100
+       OPACITY      100
+       WIDTH        2
+      END
+
+      STYLE
+       ANTIALIAS    true
+       COLOR        255 145 0 #FF9100
+       OPACITY      70
+       WIDTH        2
+      END
+
+      
+    END
+
+    CLASS
+      NAME "tijdvak_00:00_23:59"
+      EXPRESSION ("[tijdvak]" eq "00:00:00_23:59:00")
+      
+      STYLE
+       ANTIALIAS    true
+       OUTLINECOLOR 255 230 0 #FFE600
+       OPACITY      100
+       WIDTH        2
+      END
+
+      STYLE
+       ANTIALIAS    true
+       COLOR        255 230 0 #FFE600
+       OPACITY      70
+       WIDTH        2
+      END
+     
+    END
+  END
+  
+  # Regime Laden & Lossen
+
+  LAYER
+    NAME            "tijdvakken_parkeren"
+    GROUP           "regimes"
+    INCLUDE         "connection_dataservices.inc"
+    DATA            "geom FROM public.parkeervakken_parkeervakken inner join (select begin_tijd, eind_tijd, parent_id, bord from parkeervakken_parkeervakken_regimes) pvr on ID = pvr.parent_id 
+                        inner join (
+                              select '00:00:00_06:59:00' as tijdvak
+                              union 
+                              select '07:00:00_17:00:00' 
+                              union 
+                              select '17:01:00_23:59:00' 
+                              union 
+                              select '00:00:00_23:59:00' 
+                              ) AS TV ON 
+                                cast(regexp_replace(tijdvak, '^([^_]+)_([^_]+)', '\1') as time)  < eind_tijd and cast(regexp_replace(tijdvak, '^([^_]+)_([^_]+)', '\2') as time)  > begin_tijd
+                                and e_type = 'E7' and bord = 'Laden & Lossen'
+                        USING srid=28992 USING UNIQUE id"
+    TYPE            POLYGON
+    MINSCALEDENOM   100
+    MAXSCALEDENOM   400000
+    TEMPLATE        "fooOnlyForWMSGetFeatureInfo.html"
+    PROJECTION      "init=epsg:28992"
+    END
+
+    VALIDATION
+      # %onderwerp% substitutions can only have letters, digits and underscore
+      'default_bord'  'all'
+      'bord'          '^[0-9a-zA-Z_,]{1,256}$'
+    END
+
+    METADATA
+      "wfs_title"          "Laden & Lossen"
+      "wfs_srs"             "EPSG:28992"
+      "wfs_abstract"        "Laden & Lossen Amsterdam"
+      "wfs_enable_request"  "*"
+      "gml_featureid"       "titel"
+      "gml_include_items"   "all"
+      "wms_title"           "Laden & Lossen"
+      "wms_enable_request"  "*"
+      "wms_group_title"     "Regimes"
+      "wms_abstract"        "Laden & Lossen Amsterdam"
+      "wms_srs"             "EPSG:28992"
+      "wms_name"            "Laden & Lossen"
+      "wms_format"          "image/png"
+      "wms_server_version"  "1.1.1"
+      "wms_extent"          "100000 450000 150000 500000"       
+    END
+
+    CLASS
+      NAME "tijdvak_00:00_06:59"
+      EXPRESSION ("[tijdvak]" eq "00:00:00_06:59:00")      
+      
+      STYLE
+       ANTIALIAS    true
+       OUTLINECOLOR 120 120 120 #787878
+       OPACITY      100
+       WIDTH        2
+      END
+
+      STYLE
+       ANTIALIAS    true
+       COLOR        232 232 232 #E8E8E8
+       OPACITY      70
+       WIDTH        2
+      END
+      
+    END
+
+   CLASS
+      NAME "tijdvak_07:00_17:00"
+      EXPRESSION ("[tijdvak]" eq "07:00:00_17:00:00")     
+      
+      STYLE
+       ANTIALIAS    true
+       OUTLINECOLOR 120 120 120 #787878
+       OPACITY      100
+       WIDTH        2
+      END
+
+      STYLE
+       ANTIALIAS    true
+       COLOR        190 190 190 #BEBEBE
+       OPACITY      70
+       WIDTH        2
+      END      
+
+    END
+
+    CLASS
+      NAME "tijdvak_17:01_23:59"          
+      EXPRESSION ("[tijdvak]" eq "17:01:00_23:59:00")
+      
+      STYLE
+       ANTIALIAS    true
+       OUTLINECOLOR 120 120 120 #787878
+       OPACITY      100
+       WIDTH        2
+      END
+
+      STYLE
+       ANTIALIAS    true
+       COLOR        120 120 120 #787878
+       OPACITY      70
+       WIDTH        2
+      END
+    
+    END
+
+    CLASS
+      NAME "tijdvak_00:00_23:59"
+      EXPRESSION ("[tijdvak]" eq "00:00:00_23:59:00")
+     
+      STYLE
+       ANTIALIAS    true
+       OUTLINECOLOR 0 0 0 #000000
+       OPACITY      100
+       WIDTH        2
+      END
+
+      STYLE
+       ANTIALIAS    true
+       COLOR        0 0 0 #000000
+       OPACITY      70
+       WIDTH        2
+      END
+      
+    END
+  END
+
+  # Regime Kiss & Ride
+
+  LAYER
+    NAME            "tijdvakken_parkeren"
+    GROUP           "regimes"
+    INCLUDE         "connection_dataservices.inc"
+    DATA            "geom FROM public.parkeervakken_parkeervakken inner join (select begin_tijd, eind_tijd, parent_id, bord from parkeervakken_parkeervakken_regimes) pvr on ID = pvr.parent_id 
+                        inner join (
+                              select '00:00:00_06:59:00' as tijdvak
+                              union 
+                              select '07:00:00_17:00:00' 
+                              union 
+                              select '17:01:00_23:59:00' 
+                              union 
+                              select '00:00:00_23:59:00' 
+                              ) AS TV ON 
+                                cast(regexp_replace(tijdvak, '^([^_]+)_([^_]+)', '\1') as time)  < eind_tijd and cast(regexp_replace(tijdvak, '^([^_]+)_([^_]+)', '\2') as time)  > begin_tijd
+                                and e_type = 'E9' and bord = 'Kiss & Ride'
+                        USING srid=28992 USING UNIQUE id"
+    TYPE            POLYGON
+    MINSCALEDENOM   100
+    MAXSCALEDENOM   400000
+    TEMPLATE        "fooOnlyForWMSGetFeatureInfo.html"
+    PROJECTION      "init=epsg:28992"
+    END
+
+    VALIDATION
+      # %onderwerp% substitutions can only have letters, digits and underscore
+      'default_bord'  'all'
+      'bord'          '^[0-9a-zA-Z_,]{1,256}$'
+    END
+
+    METADATA
+      "wfs_title"          "Kiss & Ride"
+      "wfs_srs"             "EPSG:28992"
+      "wfs_abstract"        "Kiss & Ride Amsterdam"
+      "wfs_enable_request"  "*"
+      "gml_featureid"       "titel"
+      "gml_include_items"   "all"
+      "wms_title"           "Kiss & Ride"
+      "wms_enable_request"  "*"
+      "wms_group_title"     "Regimes"
+      "wms_abstract"        "Kiss & Ride Amsterdam"
+      "wms_srs"             "EPSG:28992"
+      "wms_name"            "Kiss & Ride"
+      "wms_format"          "image/png"
+      "wms_server_version"  "1.1.1"
+      "wms_extent"          "100000 450000 150000 500000"       
+    END
+
+    CLASS
+      NAME "tijdvak_00:00_06:59"
+      EXPRESSION ("[tijdvak]" eq "00:00:00_06:59:00")
+     
+      STYLE
+       ANTIALIAS    true
+       OUTLINECOLOR 0 70 153 #004699
+       OPACITY      100
+       WIDTH        2
+      END
+
+      STYLE
+       ANTIALIAS    true
+       COLOR        0 70 153 #004699
+       OPACITY      70
+       WIDTH        2
+      END
+
+    END
+
+   CLASS
+      NAME "tijdvak_07:00_17:00"
+      EXPRESSION ("[tijdvak]" eq "07:00:00_17:00:00")
+      
+      STYLE
+       ANTIALIAS    true
+       OUTLINECOLOR 0 157 230 #009DE6
+       OPACITY      100
+       WIDTH        2
+      END
+      
+      STYLE
+       ANTIALIAS    true
+       COLOR        0 157 230 #009DE6
+       OPACITY      70
+       WIDTH        2
+      END
+
+    END
+
+    CLASS
+      NAME "tijdvak_17:01_23:59"
+      EXPRESSION ("[tijdvak]" eq "17:01:00_23:59:00")
+      
+      STYLE
+       ANTIALIAS    true
+       OUTLINECOLOR 190 210 0 #BED200
+       OPACITY      100
+       WIDTH        2
+      END
+
+      STYLE
+       ANTIALIAS    true
+       COLOR        190 210 0 #BED200
+       OPACITY      70
+       WIDTH        2
+      END
+     
+    END
+
+    CLASS
+      NAME "tijdvak_00:00_23:59"
+      EXPRESSION ("[tijdvak]" eq "00:00:00_23:59:00")
+      
+      STYLE
+       ANTIALIAS    true
+       OUTLINECOLOR 0 160 60 #00A03C
+       OPACITY      100
+       WIDTH        2
+      END
+
+      STYLE
+       ANTIALIAS    true
+       COLOR        0 160 60 #00A03C
+       OPACITY      70
+       WIDTH        2
+      END
+     
+    END
+  END
+  
   #=============================================================================
   # LAYERS
   #=============================================================================


### PR DESCRIPTION
In the parkeervakken.map is for the regimes Taxistandplaatsen, Laden & Lossen and Kiss & Ride a layer added with classes containing predefined periods. The coloring is adjusted according the specs.

Resolves: [DS-255]