### PR TITLE
[DS-288] Added the precariobelastingen layer

### DIFF
--- a/precariobelastingen.map
+++ b/precariobelastingen.map
@@ -42,9 +42,9 @@ MAP
     END
 
     VALIDATION
-      # %tariefgebied% substitutions can only digits, underscore and semicolons
+      # %tariefgebied% substitutions can only digits and capitals
       'default_tariefgebied'  'all'
-      'tariefgebied'          '^[A-Z]+$'
+      'tariefgebied'          '^[0-9A-Z]+$'
           
     END
 
@@ -120,9 +120,9 @@ MAP
     END
 
     VALIDATION
-      # %tariefgebied% substitutions can only digits, underscore and semicolons
+      # %tariefgebied% substitutions can only digits and capitals
       'default_tariefgebied'  'all'
-      'tariefgebied'          '^[A-Z]+$'
+      'tariefgebied'          '^[0-9A-Z]+$'
           
     END
 
@@ -198,9 +198,9 @@ MAP
     END
 
     VALIDATION
-      # %tariefgebied% substitutions can only digits, underscore and semicolons
+      # %tariefgebied% substitutions can only digits and capitals
       'default_tariefgebied'  'all'
-      'tariefgebied'          '^[A-Z]+$'
+      'tariefgebied'          '^[0-9A-Z]+$'
           
     END
 
@@ -292,9 +292,9 @@ MAP
     END
 
     VALIDATION
-      # %tariefgebied% substitutions can only digits, underscore and semicolons
+      # %tariefgebied% substitutions can only digits and capitals
       'default_tariefgebied'  'all'
-      'tariefgebied'          '^[A-Z]+$'
+      'tariefgebied'          '^[0-9A-Z]+$'
           
     END
 

--- a/precariobelastingen.map
+++ b/precariobelastingen.map
@@ -1,0 +1,371 @@
+#==============================================================================
+#
+# percariobelastingen.map
+# doel: tonen van de precariobelastinggebieden voor de categorieën: (1) bedrijfsvaartuigen, (2) passagiersvaartuigen, (3) woonschepen en (4) terrassen.
+#
+#==============================================================================
+#
+# naam                  datum         wijziging
+# ------------------    ----------    -----------------------------------------
+# Chris van Riel        17-06-2020    Initiatie
+#
+#==============================================================================
+
+MAP
+  NAME "PRECARIOBELASTINGGEBIEDEN"
+  INCLUDE "header.inc"
+
+
+  WEB
+    METADATA
+      "ows_title"    "Precariobelastinggebieden"
+      "ows_abstract" "Precariobelastinggebieden waarvan Amsterdam de bronhouder is"
+    END
+  END
+
+  # CATEGORIE: BEDRIJFSVAARTUIGEN
+
+  LAYER
+    NAME            "precariobelastinggebieden_bedrijfsvaartuigen"
+    INCLUDE         "connection_dataservices.inc"
+    DATA            "geometry FROM public.precariobelasting_bedrijfsvaartuigen 
+                    INNER JOIN (
+                      select t.ID as identifier, row_number() over (order by id) as tariefgebied
+                      FROM public.precariobelasting_bedrijfsvaartuigen as t
+                    ) sub on sub.identifier = precariobelasting_bedrijfsvaartuigen.ID
+                    USING srid=28992 USING UNIQUE id"
+    TYPE            POLYGON
+    MINSCALEDENOM   100
+    MAXSCALEDENOM   400000
+    TEMPLATE        "fooOnlyForWMSGetFeatureInfo.html"
+    PROJECTION      "init=epsg:28992"
+    END
+
+    VALIDATION
+      # %tariefgebied% substitutions can only digits, underscore and semicolons
+      'default_tariefgebied'  'all'
+      'tariefgebied'          '^[A-Z]+$'
+          
+    END
+
+    METADATA
+      "wfs_title"           "Bedrijfsvaartuigen"
+      "wfs_srs"             "EPSG:28992"
+      "wfs_abstract"        "Bedrijfsvaartuigen"
+      "wfs_enable_request"  "*"
+      "gml_featureid"       "tariefgebied"
+      "gml_include_items"   "all"
+      "wms_title"           "Bedrijfsvaartuigen"
+      "wms_enable_request"  "*"
+      "wms_abstract"        "Bedrijfsvaartuigen"
+      "wms_srs"             "EPSG:28992"
+      "wms_name"            "Bedrijfsvaartuigen"
+      "wms_format"          "image/png"
+      "wms_server_version"  "1.1.1"
+      "wms_extent"          "100000 450000 150000 500000"  
+    END
+
+    CLASS
+      NAME "tariefgebied_A"
+      EXPRESSION ("[tariefgebied]" eq "1" AND ( '%tariefgebied%' eq 'A'  OR '%tariefgebied%' eq 'all' ))
+            
+     STYLE
+          ANTIALIAS    true
+          COLOR        0 160 60
+          OPACITY      35
+      END
+      STYLE
+          OUTLINECOLOR  0 160 60
+          OPACITY      100
+          WIDTH        1
+      END
+
+    END
+
+    CLASS
+      NAME "tariefgebied_B"
+      EXPRESSION ("[tariefgebied]" eq "2" AND ( '%tariefgebied%' eq 'B'  OR '%tariefgebied%' eq 'all' ))
+            
+    STYLE
+          ANTIALIAS    true
+          COLOR        160 0 120
+          OPACITY      35
+      END
+      STYLE
+          OUTLINECOLOR  160 0 120
+          OPACITY      100
+          WIDTH        1
+      END
+
+    END
+
+  END
+
+# CATEGORIE: PASSAGIERSVAARTUIGEN
+
+  LAYER
+    NAME            "precariobelastinggebieden_passagiersvaartuigen"
+    INCLUDE         "connection_dataservices.inc"
+    DATA            "geometry FROM public.precariobelasting_passagiersvaartuigen 
+                    INNER JOIN (
+                      select t.ID as identifier, row_number() over (order by id) as tariefgebied
+                      FROM public.precariobelasting_passagiersvaartuigen as t
+                    ) sub on sub.identifier = precariobelasting_passagiersvaartuigen.ID
+                    USING srid=28992 USING UNIQUE id"
+    TYPE            POLYGON
+    MINSCALEDENOM   100
+    MAXSCALEDENOM   400000
+    TEMPLATE        "fooOnlyForWMSGetFeatureInfo.html"
+    PROJECTION      "init=epsg:28992"
+    END
+
+    VALIDATION
+      # %tariefgebied% substitutions can only digits, underscore and semicolons
+      'default_tariefgebied'  'all'
+      'tariefgebied'          '^[A-Z]+$'
+          
+    END
+
+    METADATA
+      "wfs_title"           "Passagiersvaartuigen"
+      "wfs_srs"             "EPSG:28992"
+      "wfs_abstract"        "Passagiersvaartuigen"
+      "wfs_enable_request"  "*"
+      "gml_featureid"       "tariefgebied"
+      "gml_include_items"   "all"
+      "wms_title"           "Passagiersvaartuigen"
+      "wms_enable_request"  "*"
+      "wms_abstract"        "Passagiersvaartuigen"
+      "wms_srs"             "EPSG:28992"
+      "wms_name"            "Passagiersvaartuigen"
+      "wms_format"          "image/png"
+      "wms_server_version"  "1.1.1"
+      "wms_extent"          "100000 450000 150000 500000"  
+    END
+
+    CLASS
+      NAME "tariefgebied_A"
+      EXPRESSION ("[tariefgebied]" eq "1" AND ( '%tariefgebied%' eq 'A'  OR '%tariefgebied%' eq 'all' ))
+            
+       STYLE
+          ANTIALIAS    true
+          COLOR        0 157 230
+          OPACITY      35
+      END
+      STYLE
+          OUTLINECOLOR 0 157 230
+          OPACITY      100
+          WIDTH        1
+      END
+
+    END
+
+    CLASS
+      NAME "tariefgebied_B"
+      EXPRESSION ("[tariefgebied]" eq "2" AND ( '%tariefgebied%' eq 'B'  OR '%tariefgebied%' eq 'all' ))
+            
+      STYLE
+          ANTIALIAS    true
+          COLOR        236 0 0
+          OPACITY      35
+      END
+      STYLE
+          OUTLINECOLOR  236 0 0
+          OPACITY      100
+          WIDTH        1
+      END
+
+    END
+
+  END
+
+# CATEGORIE: WOONSCHEPEN
+
+  LAYER
+    NAME            "precariobelastinggebieden_woonschepen"
+    INCLUDE         "connection_dataservices.inc"
+    DATA            "geometry FROM public.precariobelasting_woonschepen 
+                    INNER JOIN (
+                      select t.ID as identifier, row_number() over (order by id) as tariefgebied
+                      FROM public.precariobelasting_woonschepen as t
+                    ) sub on sub.identifier = precariobelasting_woonschepen.ID
+                    USING srid=28992 USING UNIQUE id"
+    TYPE            POLYGON
+    MINSCALEDENOM   100
+    MAXSCALEDENOM   400000
+    TEMPLATE        "fooOnlyForWMSGetFeatureInfo.html"
+    PROJECTION      "init=epsg:28992"
+    END
+
+    VALIDATION
+      # %tariefgebied% substitutions can only digits, underscore and semicolons
+      'default_tariefgebied'  'all'
+      'tariefgebied'          '^[A-Z]+$'
+          
+    END
+
+    METADATA
+      "wfs_title"           "Woonschepen"
+      "wfs_srs"             "EPSG:28992"
+      "wfs_abstract"        "Woonschepen"
+      "wfs_enable_request"  "*"
+      "gml_featureid"       "tariefgebied"
+      "gml_include_items"   "all"
+      "wms_title"           "Woonschepen"
+      "wms_enable_request"  "*"
+      "wms_abstract"        "Woonschepen"
+      "wms_srs"             "EPSG:28992"
+      "wms_name"            "Woonschepen"
+      "wms_format"          "image/png"
+      "wms_server_version"  "1.1.1"
+      "wms_extent"          "100000 450000 150000 500000"  
+    END
+
+    CLASS
+      NAME "tariefgebied_A"
+      EXPRESSION ("[tariefgebied]" eq "1" AND ( '%tariefgebied%' eq 'A'  OR '%tariefgebied%' eq 'all' ))
+            
+      STYLE
+          ANTIALIAS    true
+          COLOR        236 0 0
+          OPACITY      35
+      END
+      STYLE
+          OUTLINECOLOR  236 0 0
+          OPACITY      100
+          WIDTH        1
+      END
+    END
+
+    CLASS
+      NAME "tariefgebied_B"
+      EXPRESSION ("[tariefgebied]" eq "2" AND ( '%tariefgebied%' eq 'B'  OR '%tariefgebied%' eq 'all' ))
+            
+      STYLE
+          ANTIALIAS    true
+          COLOR        255 145 0
+          OPACITY      35
+      END
+      STYLE
+          OUTLINECOLOR  255 145 0
+          OPACITY      100
+          WIDTH        1
+      END
+
+    END
+
+    CLASS
+      NAME "tariefgebied_C"
+      EXPRESSION ("[tariefgebied]" eq "3" AND ( '%tariefgebied%' eq 'C'  OR '%tariefgebied%' eq 'all' ))
+        
+      STYLE
+          ANTIALIAS    true
+          COLOR        255 230 0
+          OPACITY      35
+      END
+      STYLE
+          OUTLINECOLOR  255 230 0
+          OPACITY      100
+          WIDTH        1
+      END
+
+    END
+
+  END
+
+# CATEGORIE: TERRASSEN
+
+  LAYER
+    NAME            "precariobelastinggebieden_terrassen"
+    INCLUDE         "connection_dataservices.inc"
+    DATA            "geometry FROM public.precariobelasting_terrassen 
+                    INNER JOIN (
+                      select t.ID as identifier, row_number() over (order by id) as tariefgebied
+                      FROM public.precariobelasting_terrassen as t
+                    ) sub on sub.identifier = precariobelasting_terrassen.ID
+                    USING srid=28992 USING UNIQUE id"
+    TYPE            POLYGON
+    MINSCALEDENOM   100
+    MAXSCALEDENOM   400000
+    TEMPLATE        "fooOnlyForWMSGetFeatureInfo.html"
+    PROJECTION      "init=epsg:28992"
+    END
+
+    VALIDATION
+      # %tariefgebied% substitutions can only digits, underscore and semicolons
+      'default_tariefgebied'  'all'
+      'tariefgebied'          '^[A-Z]+$'
+          
+    END
+
+    METADATA
+      "wfs_title"           "Terrassen"
+      "wfs_srs"             "EPSG:28992"
+      "wfs_abstract"        "Terrassen"
+      "wfs_enable_request"  "*"
+      "gml_featureid"       "tariefgebied"
+      "gml_include_items"   "all"
+      "wms_title"           "Terrassen"
+      "wms_enable_request"  "*"
+      "wms_abstract"        "Terrassen"
+      "wms_srs"             "EPSG:28992"
+      "wms_name"            "Terrassen"
+      "wms_format"          "image/png"
+      "wms_server_version"  "1.1.1"
+      "wms_extent"          "100000 450000 150000 500000"  
+    END
+
+    CLASS
+      NAME "tariefgebied_A"
+      EXPRESSION ("[tariefgebied]" eq "1" AND ( '%tariefgebied%' eq 'A'  OR '%tariefgebied%' eq 'all' ))
+            
+      STYLE
+          ANTIALIAS    true
+          COLOR        0 157 230
+          OPACITY      35
+      END
+      STYLE
+          OUTLINECOLOR 0 157 230
+          OPACITY      100
+          WIDTH        1
+      END
+
+    END
+
+    CLASS
+      NAME "tariefgebied_B"
+      EXPRESSION ("[tariefgebied]" eq "2" AND ( '%tariefgebied%' eq 'B'  OR '%tariefgebied%' eq 'all' ))
+            
+      STYLE
+          ANTIALIAS    true
+          COLOR        160 0 120
+          OPACITY      35
+      END
+      STYLE
+          OUTLINECOLOR  160 0 120
+          OPACITY      100
+          WIDTH        1
+      END
+
+    END
+
+    CLASS
+      NAME "tariefgebied_C"
+      EXPRESSION ("[tariefgebied]" eq "3" AND ( '%tariefgebied%' eq 'C'  OR '%tariefgebied%' eq 'all' ))
+        
+      STYLE
+          ANTIALIAS    true
+          COLOR        0 160 60
+          OPACITY      35
+      END
+      STYLE
+          OUTLINECOLOR  0 160 60
+          OPACITY      100
+          WIDTH        1
+      END
+
+    END
+
+  END
+#=============================================================================
+END


### PR DESCRIPTION
**Contains 4 categories:**

1. - Bedrijfsvaartuigen  -- tariefgebied_A en B
2. - Passagiersvaartuigen  -- tariefgebied_A en B
3. - Woonschepen  -- tariefgebied_A, B en C
4. - Terrassen  -- tariefgebied_A, B en C

Colors tariefgebieden conform specs.

**URL param filter option:** tariefgebied
**URL param filter option values:** A, B or C

**Example:**
_var wmsLayer = L.tileLayer.wms('http://localhost:8383/maps/precariobelastingen?tariefgebied=B&version=1.3.0&service=WMS', {
     layers: ['precariobelastinggebieden_passagiersvaartuigen', 'precariobelastinggebieden_terrassen'],
     transparent: true,
     format: 'image/png',
     isBaseLayer : false,
     tiled: true,
     maxBounds: BOUNDS,
     crs: L.CRS.RD
     } ).addTo(mymap);_

Resolves: [DS-288]