### PR TITLE
[DS-352] Replaced titel by omschrijving in Touringcars

### DIFF
--- a/precariobelastingen.map
+++ b/precariobelastingen.map
@@ -162,7 +162,7 @@ MAP
           TEXT           "Tariefgebied 1"
       END
 
-    END
+    END 
 
     CLASS
       NAME "tariefgebied_2"
@@ -439,4 +439,3 @@ MAP
   END
 END
 #=============================================================================
-END

--- a/touringcars.map
+++ b/touringcars.map
@@ -14,6 +14,7 @@
 # naam                  datum         wijziging
 # ------------------    ----------    -----------------------------------------
 # Chris van Riel        29-06-2020    Initiatie
+# CHris van Riel        08-07-2020    Replaced field titel by omschrijving (new specs)
 #
 #==============================================================================
 
@@ -60,7 +61,7 @@ MAP
     END
 
       
-    LABELITEM               "titel"
+    LABELITEM               "omschrijving"
 
     CLASS
       NAME                  "maximale doorrijhoogtes"
@@ -118,7 +119,7 @@ MAP
     END
 
       
-    LABELITEM               "titel"
+    LABELITEM               "omschrijving"
 
     FILTER                 ("1" = '1')
 
@@ -179,7 +180,7 @@ MAP
     END
 
       
-    LABELITEM               "titel"
+    LABELITEM               "omschrijving"
 
     FILTER                 ("1" = '1')
 
@@ -240,7 +241,7 @@ MAP
     END
 
       
-    LABELITEM               "titel"
+    LABELITEM               "omschrijving"
 
     FILTER                 ("1" = '1')
 
@@ -307,7 +308,7 @@ MAP
 
          
       
-    LABELITEM               "titel"
+    LABELITEM               "omschrijving"
 
     CLASS
       NAME                  "touringcars_aanbevolenroutes"
@@ -369,7 +370,7 @@ MAP
     END
 
       
-    LABELITEM               "titel"
+    LABELITEM               "omschrijving"
 
     FILTER                 ("1" = '1')
 


### PR DESCRIPTION
Due to new specs the titel field is replaced by omschrijving.
Also removed an unnecessary END tag in the precariobelastingen.

Resolves: [DS-352]

[DS-352]: https://datapunt.atlassian.net/browse/DS-352