### PR TITLE
Remove old pid file before starting  apache server.

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -236,4 +236,6 @@ mkdir -p /srv/mapserver/config
 python3 /srv/mapserver/tools/make_mapfile_config.py > /srv/mapserver/sld/config.json
 
 echo Starting server
+# Apache gets grumpy about PID files pre-existing
+rm -f /var/run/apache2/apache2.pid
 apachectl -D FOREGROUND


### PR DESCRIPTION
This is a attempt to fix reboot container problems. Perhaps the  image is
kept after a container reboot, and the existing pid file gives problems when starting
apache. This is copied from the official apache httpd docker repository

https://github.com/docker-library/httpd/blob/master/2.4/httpd-foreground