### PR TITLE
Remove Access-Control-Allow-Origin header in Apache

### DIFF
--- a/docker/000-default.conf
+++ b/docker/000-default.conf
@@ -30,7 +30,6 @@
   RewriteCond %{REQUEST_URI} ^/$
   Rewriterule ^(.*)$ https://api.data.amsterdam.nl/api/ [L,R=301]
 
-  Header always set Access-Control-Allow-Origin "*"
   Header always set Access-Control-Allow-Methods "POST, GET, OPTIONS"
   Header always set Access-Control-Allow-Headers "Authorization, kbn-version, Origin, X-Requested-With, Content-Type, Accept, Client-Security-Token"
 


### PR DESCRIPTION
This will be added by HAProxy and then contain only the origin