### PR TITLE
changed color for categorie 350 - 370 M

### DIFF
--- a/afval.map
+++ b/afval.map
@@ -3984,11 +3984,11 @@ MAP
       EXPRESSION ("[loopafstand_categorie_omschrijving]" eq "350 - 370 M")
       STYLE
             ANTIALIAS    true
-            COLOR        255 127 0
+            COLOR        253 191 111         
             OPACITY      100
         END
         STYLE
-            OUTLINECOLOR  128 62 0
+            OUTLINECOLOR 253 170 111
             OPACITY      100
             WIDTH        1
         END


### PR DESCRIPTION
On request of datateam beeldschoon, changed the color definition of the category 350-370 M for loopafstanden container Textiel