### PR TITLE
[NEW] wegenbestand dataset

### DIFF
--- a/wegenbestand.map
+++ b/wegenbestand.map
@@ -1,0 +1,257 @@
+MAP
+  NAME                      "wegenbestand"
+  INCLUDE                   "header.inc"
+  DEBUG 1
+
+  WEB
+    METADATA
+      "ows_title"           "Wegenbestand"
+      "ows_abstract"        "Wegenbestand gemeente Amsterdam"
+      "wms_extent"          "100000 450000 150000 500000"
+    END
+  END
+
+
+  LEGEND
+     STATUS ON
+     KEYSIZE 17 17
+  END
+
+# ------------------------------------------------------------------------
+
+  LAYER
+    NAME                    "binnen"
+    GROUP                   "zone zwaarverkeer"
+    PROJECTION
+      "init=epsg:28992"
+    END
+
+    INCLUDE                 "connection_dataservices.inc"
+    DATA                    "geometry FROM public.wegenbestand_zone_zwaarverkeer_binnen USING srid=28992 USING UNIQUE id"
+    TYPE                    LINE
+    MINSCALEDENOM           10
+    MAXSCALEDENOM           400000
+
+
+    METADATA
+      "wfs_title"           "binnen"
+      "wfs_srs"             "EPSG:28992"
+      "wfs_abstract"        "binnen"
+      "wfs_enable_request"  "*"
+      "gml_featureid"       "name"
+      "gml_include_items"   "all"
+      "wms_title"           "binnen"
+      "wms_enable_request"  "*"
+      "wms_group_title"     "zone zwaarverkeer"
+      "wms_abstract"        "binnen"
+      "wms_srs"             "EPSG:28992"
+      "wms_name"            "binnen"
+      "wms_format"          "image/png"
+      "wms_server_version"  "1.1.1"
+      "wms_extent"          "100000 450000 150000 500000"
+    END
+
+    CLASS
+      NAME          "binnen"
+
+      STYLE
+          WIDTH        2
+          COLOR        204 0 153
+          OUTLINECOLOR 204 0 153
+      END
+    END
+  END
+
+# ------------------------------------------------------------------------
+
+  LAYER
+    NAME                    "buiten"
+    GROUP                   "zone zwaarverkeer"
+    PROJECTION
+      "init=epsg:28992"
+    END
+
+    INCLUDE                 "connection_dataservices.inc"
+    DATA                    "geometry FROM public.wegenbestand_zone_zwaarverkeer_buiten USING srid=28992 USING UNIQUE id"
+    TYPE                    LINE
+    MINSCALEDENOM           10
+    MAXSCALEDENOM           400000
+
+
+    METADATA
+      "wfs_title"           "buiten"
+      "wfs_srs"             "EPSG:28992"
+      "wfs_abstract"        "buiten"
+      "wfs_enable_request"  "*"
+      "gml_featureid"       "name"
+      "gml_include_items"   "all"
+      "wms_title"           "buiten"
+      "wms_enable_request"  "*"
+      "wms_group_title"     "zone zwaarverkeer"
+      "wms_abstract"        "buiten"
+      "wms_srs"             "EPSG:28992"
+      "wms_name"            "buiten"
+      "wms_format"          "image/png"
+      "wms_server_version"  "1.1.1"
+      "wms_extent"          "100000 450000 150000 500000"
+    END
+
+    CLASS
+      NAME          "buiten"
+
+      STYLE
+          WIDTH        2
+          COLOR        0 51 204
+          OUTLINECOLOR 0 51 204
+      END
+    END
+  END
+
+# ------------------------------------------------------------------------
+
+  LAYER
+    NAME                    "buiten - breed_opgezette_wegen"
+    GROUP                   "zone zwaarverkeer"
+    PROJECTION
+      "init=epsg:28992"
+    END
+
+    INCLUDE                 "connection_dataservices.inc"
+    DATA                    "geometry FROM public.wegenbestand_zone_zwaarverkeer_breed_opgezette_wegen USING srid=28992 USING UNIQUE id"
+    TYPE                    LINE
+    MINSCALEDENOM           10
+    MAXSCALEDENOM           400000
+
+
+    METADATA
+      "wfs_title"           "buiten - breed_opgezette_wegen"
+      "wfs_srs"             "EPSG:28992"
+      "wfs_abstract"        "buiten - breed_opgezette_wegen"
+      "wfs_enable_request"  "*"
+      "gml_featureid"       "name"
+      "gml_include_items"   "all"
+      "wms_title"           "buiten - breed_opgezette_wegen"
+      "wms_enable_request"  "*"
+      "wms_group_title"     "zone zwaarverkeer"
+      "wms_abstract"        "buiten - breed_opgezette_wegen"
+      "wms_srs"             "EPSG:28992"
+      "wms_name"            "buiten - breed_opgezette_wegen"
+      "wms_format"          "image/png"
+      "wms_server_version"  "1.1.1"
+      "wms_extent"          "100000 450000 150000 500000"
+    END
+
+    CLASS
+      NAME          "buiten - breed_opgezette_wegen"
+
+      STYLE
+          WIDTH        3
+          COLOR        255 0 0
+          OUTLINECOLOR 255 0 0
+      END
+    END
+  END
+
+# ------------------------------------------------------------------------
+
+  LAYER
+    NAME                    "gevaarlijke_stoffen"
+    GROUP                   "zone zwaarverkeer"
+    PROJECTION
+      "init=epsg:28992"
+    END
+
+    INCLUDE                 "connection_dataservices.inc"
+    DATA                    "geometry FROM public.wegenbestand_zone_zwaarverkeer_routes_gevaarlijke_stoffen USING srid=28992 USING UNIQUE id"
+    TYPE                    LINE
+    MINSCALEDENOM           10
+    MAXSCALEDENOM           400000
+
+
+    METADATA
+      "wfs_title"           "Gevaarlijke stoffen"
+      "wfs_srs"             "EPSG:28992"
+      "wfs_abstract"        "Gevaarlijke stoffen"
+      "wfs_enable_request"  "*"
+      "gml_featureid"       "name"
+      "gml_include_items"   "all"
+      "wms_title"           "Gevaarlijke stoffen"
+      "wms_enable_request"  "*"
+      "wms_group_title"     "zone zwaarverkeer"
+      "wms_abstract"        "Gevaarlijke stoffen"
+      "wms_srs"             "EPSG:28992"
+      "wms_name"            "gevaarlijke_stoffen"
+      "wms_format"          "image/png"
+      "wms_server_version"  "1.1.1"
+      "wms_extent"          "100000 450000 150000 500000"
+    END
+
+    CLASS
+      NAME          "Gevaarlijke stoffen"
+
+      STYLE
+          WIDTH        2
+          COLOR        255 145 0
+          OUTLINECOLOR 255 145 0
+      END
+    END
+  END
+
+# ------------------------------------------------------------------------
+
+  LAYER
+    NAME                    "tunnels"
+    GROUP                   "zone zwaarverkeer"
+    PROJECTION
+      "init=epsg:28992"
+    END
+
+    INCLUDE                 "connection_dataservices.inc"
+    DATA                    "geometry FROM public.wegenbestand_zone_zwaarverkeer_tunnels_gevaarlijke_stoffen USING srid=28992 USING UNIQUE id"
+    TYPE                    POINT
+    MINSCALEDENOM           10
+    MAXSCALEDENOM           400000
+
+
+    METADATA
+      "wfs_title"           "Tunnels gevaarlijke stoffen"
+      "wfs_srs"             "EPSG:28992"
+      "wfs_abstract"        "Tunnels gevaarlijke stoffen"
+      "wfs_enable_request"  "*"
+      "gml_featureid"       "name"
+      "gml_include_items"   "all"
+      "wms_title"           "Tunnels gevaarlijke stoffen"
+      "wms_enable_request"  "*"
+      "wms_group_title"     "zone zwaarverkeer"
+      "wms_abstract"        "Tunnels gevaarlijke stoffen"
+      "wms_srs"             "EPSG:28992"
+      "wms_name"            "tunnels"
+      "wms_format"          "image/png"
+      "wms_server_version"  "1.1.1"
+      "wms_extent"          "100000 450000 150000 500000"
+    END
+
+    CLASS
+      NAME          "Tunnels gevaarlijke stoffen"
+
+      STYLE
+          SYMBOL         'cirkel_oranje_tunnel'
+          SIZE           16
+      END
+
+      LABEL
+        MINSCALEDENOM  10
+        MAXSCALEDENOM  10000
+        COLOR          0 0 0
+        OUTLINECOLOR   255 255 255
+        OUTLINEWIDTH   3
+        FONT           "Ubuntu-MI"
+        TYPE           truetype
+        SIZE           10
+        POSITION       AUTO
+        PARTIALS       FALSE
+        OFFSET         -60 10
+      END
+    END
+  END
+END

--- a/wegenbestand.map
+++ b/wegenbestand.map
@@ -21,13 +21,13 @@ MAP
 
   LAYER
     NAME                    "binnen"
-    GROUP                   "zone zwaarverkeer"
+    GROUP                   "zone zwaar verkeer"
     PROJECTION
       "init=epsg:28992"
     END
 
     INCLUDE                 "connection_dataservices.inc"
-    DATA                    "geometry FROM public.wegenbestand_zone_zwaarverkeer_binnen USING srid=28992 USING UNIQUE id"
+    DATA                    "geometry FROM public.wegenbestand_zone_zwaar_verkeer_binnen USING srid=28992 USING UNIQUE id"
     TYPE                    LINE
     MINSCALEDENOM           10
     MAXSCALEDENOM           400000
@@ -42,8 +42,8 @@ MAP
       "gml_include_items"   "all"
       "wms_title"           "binnen"
       "wms_enable_request"  "*"
-      "wms_group_title"     "zone zwaarverkeer"
-      "wms_abstract"        "binnen"
+      "wms_group_title"     "zone zwaar verkeer"
+      "wms_abstract"        "wegen die vallen binnen de zone zwaar verkeer"
       "wms_srs"             "EPSG:28992"
       "wms_name"            "binnen"
       "wms_format"          "image/png"
@@ -56,8 +56,8 @@ MAP
 
       STYLE
           WIDTH        2
-          COLOR        204 0 153
-          OUTLINECOLOR 204 0 153
+          COLOR        180 55 229
+          OUTLINECOLOR 180 55 229
       END
     END
   END
@@ -66,13 +66,13 @@ MAP
 
   LAYER
     NAME                    "buiten"
-    GROUP                   "zone zwaarverkeer"
+    GROUP                   "zone zwaar verkeer"
     PROJECTION
       "init=epsg:28992"
     END
 
     INCLUDE                 "connection_dataservices.inc"
-    DATA                    "geometry FROM public.wegenbestand_zone_zwaarverkeer_buiten USING srid=28992 USING UNIQUE id"
+    DATA                    "geometry FROM public.wegenbestand_zone_zwaar_verkeer_buiten USING srid=28992 USING UNIQUE id"
     TYPE                    LINE
     MINSCALEDENOM           10
     MAXSCALEDENOM           400000
@@ -87,8 +87,8 @@ MAP
       "gml_include_items"   "all"
       "wms_title"           "buiten"
       "wms_enable_request"  "*"
-      "wms_group_title"     "zone zwaarverkeer"
-      "wms_abstract"        "buiten"
+      "wms_group_title"     "zone zwaar verkeer"
+      "wms_abstract"        "wegen die vallen buiten de zone zwaar verkeer"
       "wms_srs"             "EPSG:28992"
       "wms_name"            "buiten"
       "wms_format"          "image/png"
@@ -101,8 +101,8 @@ MAP
 
       STYLE
           WIDTH        2
-          COLOR        0 51 204
-          OUTLINECOLOR 0 51 204
+          COLOR        40 167 69
+          OUTLINECOLOR 40 167 69
       END
     END
   END
@@ -111,13 +111,13 @@ MAP
 
   LAYER
     NAME                    "buiten - breed_opgezette_wegen"
-    GROUP                   "zone zwaarverkeer"
+    GROUP                   "zone zwaar verkeer"
     PROJECTION
       "init=epsg:28992"
     END
 
     INCLUDE                 "connection_dataservices.inc"
-    DATA                    "geometry FROM public.wegenbestand_zone_zwaarverkeer_breed_opgezette_wegen USING srid=28992 USING UNIQUE id"
+    DATA                    "geometry FROM public.wegenbestand_zone_zwaar_verkeer_breed_opgezette_wegen USING srid=28992 USING UNIQUE id"
     TYPE                    LINE
     MINSCALEDENOM           10
     MAXSCALEDENOM           400000
@@ -132,7 +132,7 @@ MAP
       "gml_include_items"   "all"
       "wms_title"           "buiten - breed_opgezette_wegen"
       "wms_enable_request"  "*"
-      "wms_group_title"     "zone zwaarverkeer"
+      "wms_group_title"     "zone zwaar verkeer"
       "wms_abstract"        "buiten - breed_opgezette_wegen"
       "wms_srs"             "EPSG:28992"
       "wms_name"            "buiten - breed_opgezette_wegen"
@@ -146,8 +146,8 @@ MAP
 
       STYLE
           WIDTH        3
-          COLOR        255 0 0
-          OUTLINECOLOR 255 0 0
+          COLOR        83 2 46
+          OUTLINECOLOR 83 2 46
       END
     END
   END
@@ -156,13 +156,13 @@ MAP
 
   LAYER
     NAME                    "gevaarlijke_stoffen"
-    GROUP                   "zone zwaarverkeer"
+    GROUP                   "zone zwaar verkeer"
     PROJECTION
       "init=epsg:28992"
     END
 
     INCLUDE                 "connection_dataservices.inc"
-    DATA                    "geometry FROM public.wegenbestand_zone_zwaarverkeer_routes_gevaarlijke_stoffen USING srid=28992 USING UNIQUE id"
+    DATA                    "geometry FROM public.wegenbestand_routes_gevaarlijke_stoffen USING srid=28992 USING UNIQUE id"
     TYPE                    LINE
     MINSCALEDENOM           10
     MAXSCALEDENOM           400000
@@ -177,7 +177,7 @@ MAP
       "gml_include_items"   "all"
       "wms_title"           "Gevaarlijke stoffen"
       "wms_enable_request"  "*"
-      "wms_group_title"     "zone zwaarverkeer"
+      "wms_group_title"     "zone zwaar verkeer"
       "wms_abstract"        "Gevaarlijke stoffen"
       "wms_srs"             "EPSG:28992"
       "wms_name"            "gevaarlijke_stoffen"
@@ -201,13 +201,13 @@ MAP
 
   LAYER
     NAME                    "tunnels"
-    GROUP                   "zone zwaarverkeer"
+    GROUP                   "zone zwaar verkeer"
     PROJECTION
       "init=epsg:28992"
     END
 
     INCLUDE                 "connection_dataservices.inc"
-    DATA                    "geometry FROM public.wegenbestand_zone_zwaarverkeer_tunnels_gevaarlijke_stoffen USING srid=28992 USING UNIQUE id"
+    DATA                    "geometry FROM public.wegenbestand_tunnels_gevaarlijke_stoffen USING srid=28992 USING UNIQUE id"
     TYPE                    POINT
     MINSCALEDENOM           10
     MAXSCALEDENOM           400000
@@ -222,7 +222,7 @@ MAP
       "gml_include_items"   "all"
       "wms_title"           "Tunnels gevaarlijke stoffen"
       "wms_enable_request"  "*"
-      "wms_group_title"     "zone zwaarverkeer"
+      "wms_group_title"     "zone zwaar verkeer"
       "wms_abstract"        "Tunnels gevaarlijke stoffen"
       "wms_srs"             "EPSG:28992"
       "wms_name"            "tunnels"

--- a/wegenbestand.map
+++ b/wegenbestand.map
@@ -157,7 +157,7 @@ MAP
 
   LAYER
     NAME                    "gevaarlijke_stoffen"
-    GROUP                   "zone zwaar verkeer"
+    GROUP                   "wegenbestand"
     PROJECTION
       "init=epsg:28992"
     END
@@ -178,7 +178,7 @@ MAP
       "gml_include_items"   "all"
       "wms_title"           "Gevaarlijke stoffen"
       "wms_enable_request"  "*"
-      "wms_group_title"     "zone zwaar verkeer"
+      "wms_group_title"     "wegenbestand"
       "wms_abstract"        "Gevaarlijke stoffen"
       "wms_srs"             "EPSG:28992"
       "wms_name"            "gevaarlijke_stoffen"
@@ -202,7 +202,7 @@ MAP
 
   LAYER
     NAME                    "tunnels"
-    GROUP                   "zone zwaar verkeer"
+    GROUP                   "wegenbestand"
     PROJECTION
       "init=epsg:28992"
     END
@@ -223,7 +223,7 @@ MAP
       "gml_include_items"   "all"
       "wms_title"           "Tunnels gevaarlijke stoffen"
       "wms_enable_request"  "*"
-      "wms_group_title"     "zone zwaar verkeer"
+      "wms_group_title"     "wegenbestand"
       "wms_abstract"        "Tunnels gevaarlijke stoffen"
       "wms_srs"             "EPSG:28992"
       "wms_name"            "tunnels"

--- a/wegenbestand.map
+++ b/wegenbestand.map
@@ -72,7 +72,9 @@ MAP
     END
 
     INCLUDE                 "connection_dataservices.inc"
-    DATA                    "geometry FROM public.wegenbestand_zone_zwaar_verkeer_buiten USING srid=28992 USING UNIQUE id"
+    # mapserver treats in the `EXPRESSION` clause on the `CLASS` NULL values as integer zero. In this case we do not want that
+    # and translate NULL values to an integer of 4 (or more). Hence the `COALESCE` in the `DATA` query below.
+    DATA                    "geometry FROM (SELECT *, COALESCE(weg_functie, 4) weg_functie_null_trans FROM public.wegenbestand_zone_zwaar_verkeer_buiten) as SUBQUERY USING srid=28992 USING UNIQUE id"
     TYPE                    LINE
     MINSCALEDENOM           10
     MAXSCALEDENOM           400000
@@ -98,7 +100,7 @@ MAP
 
     CLASS
       NAME          "buiten-wegfunctie-kleiner-dan-4"
-      EXPRESSION    ([weg_functie] < 4)
+      EXPRESSION    ([weg_functie_null_trans] < 4)
 
       STYLE
           WIDTH        2.5
@@ -110,7 +112,7 @@ MAP
 
     CLASS
       NAME          "buiten-wegfunctie-4-of-groter"
-      EXPRESSION    ([weg_functie] >= 4)
+      EXPRESSION    ([weg_functie_null_trans] >= 4)
 
       STYLE
           WIDTH        1

--- a/wegenbestand.map
+++ b/wegenbestand.map
@@ -110,7 +110,7 @@ MAP
 # ------------------------------------------------------------------------
 
   LAYER
-    NAME                    "buiten - breed_opgezette_wegen"
+    NAME                    "binnen - breed_opgezette_wegen"
     GROUP                   "zone zwaar verkeer"
     PROJECTION
       "init=epsg:28992"
@@ -124,25 +124,25 @@ MAP
 
 
     METADATA
-      "wfs_title"           "buiten - breed_opgezette_wegen"
+      "wfs_title"           "binnen - breed_opgezette_wegen"
       "wfs_srs"             "EPSG:28992"
-      "wfs_abstract"        "buiten - breed_opgezette_wegen"
+      "wfs_abstract"        "binnen - breed_opgezette_wegen"
       "wfs_enable_request"  "*"
       "gml_featureid"       "name"
       "gml_include_items"   "all"
-      "wms_title"           "buiten - breed_opgezette_wegen"
+      "wms_title"           "binnen - breed_opgezette_wegen"
       "wms_enable_request"  "*"
       "wms_group_title"     "zone zwaar verkeer"
-      "wms_abstract"        "buiten - breed_opgezette_wegen"
+      "wms_abstract"        "binnen - breed_opgezette_wegen"
       "wms_srs"             "EPSG:28992"
-      "wms_name"            "buiten - breed_opgezette_wegen"
+      "wms_name"            "binnen - breed_opgezette_wegen"
       "wms_format"          "image/png"
       "wms_server_version"  "1.1.1"
       "wms_extent"          "100000 450000 150000 500000"
     END
 
     CLASS
-      NAME          "buiten - breed_opgezette_wegen"
+      NAME          "binnen - breed_opgezette_wegen"
 
       STYLE
           WIDTH        10

--- a/wegenbestand.map
+++ b/wegenbestand.map
@@ -145,9 +145,10 @@ MAP
       NAME          "buiten - breed_opgezette_wegen"
 
       STYLE
-          WIDTH        3
+          WIDTH        10
           COLOR        83 2 46
           OUTLINECOLOR 83 2 46
+          OPACITY      50
       END
     END
   END

--- a/wegenbestand.map
+++ b/wegenbestand.map
@@ -5,7 +5,7 @@ MAP
 
   WEB
     METADATA
-      "ows_title"           "Wegenbestand"
+      "ows_title"           "wegenbestand"
       "ows_abstract"        "Wegenbestand gemeente Amsterdam"
       "wms_extent"          "100000 450000 150000 500000"
     END
@@ -55,9 +55,9 @@ MAP
       NAME          "binnen"
 
       STYLE
-          WIDTH        2
-          COLOR        180 55 229
-          OUTLINECOLOR 180 55 229
+          WIDTH        1
+          COLOR        231 142 189
+          OUTLINECOLOR 231 142 189
       END
     END
   END
@@ -97,20 +97,34 @@ MAP
     END
 
     CLASS
-      NAME          "buiten"
+      NAME          "buiten-wegfunctie-kleiner-dan-4"
+      EXPRESSION    ([weg_functie] < 4)
 
       STYLE
-          WIDTH        2
-          COLOR        40 167 69
-          OUTLINECOLOR 40 167 69
+          WIDTH        2.5
+          COLOR        60 171 84
+          OUTLINECOLOR 60 171 84
+          OPACITY      80
       END
     END
+
+    CLASS
+      NAME          "buiten-wegfunctie-4-of-groter"
+      EXPRESSION    ([weg_functie] >= 4)
+
+      STYLE
+          WIDTH        1
+          COLOR        131 193 145
+          OUTLINECOLOR 131 193 145
+      END
+    END
+
   END
 
 # ------------------------------------------------------------------------
 
   LAYER
-    NAME                    "binnen - breed_opgezette_wegen"
+    NAME                    "binnen-breed-opgezette-wegen"
     GROUP                   "zone zwaar verkeer"
     PROJECTION
       "init=epsg:28992"
@@ -124,31 +138,31 @@ MAP
 
 
     METADATA
-      "wfs_title"           "binnen - breed_opgezette_wegen"
+      "wfs_title"           "binnen-breed-opgezette-wegen"
       "wfs_srs"             "EPSG:28992"
-      "wfs_abstract"        "binnen - breed_opgezette_wegen"
+      "wfs_abstract"        "binnen-breed-opgezette-wegen"
       "wfs_enable_request"  "*"
       "gml_featureid"       "name"
       "gml_include_items"   "all"
-      "wms_title"           "binnen - breed_opgezette_wegen"
+      "wms_title"           "binnen-breed-opgezette-wegen"
       "wms_enable_request"  "*"
       "wms_group_title"     "zone zwaar verkeer"
-      "wms_abstract"        "binnen - breed_opgezette_wegen"
+      "wms_abstract"        "binnen-breed-opgezette-wegen"
       "wms_srs"             "EPSG:28992"
-      "wms_name"            "binnen - breed_opgezette_wegen"
+      "wms_name"            "binnen-breed-opgezette-wegen"
       "wms_format"          "image/png"
       "wms_server_version"  "1.1.1"
       "wms_extent"          "100000 450000 150000 500000"
     END
 
     CLASS
-      NAME          "binnen - breed_opgezette_wegen"
+      NAME          "binnen-breed-opgezette-wegen"
 
       STYLE
-          WIDTH        10
+          WIDTH        2.5
           COLOR        83 2 46
           OUTLINECOLOR 83 2 46
-          OPACITY      50
+          OPACITY      80
       END
     END
   END
@@ -156,7 +170,7 @@ MAP
 # ------------------------------------------------------------------------
 
   LAYER
-    NAME                    "gevaarlijke_stoffen"
+    NAME                    "routes-gevaarlijke-stoffen"
     GROUP                   "wegenbestand"
     PROJECTION
       "init=epsg:28992"
@@ -170,28 +184,28 @@ MAP
 
 
     METADATA
-      "wfs_title"           "Gevaarlijke stoffen"
+      "wfs_title"           "routes-gevaarlijke-stoffen"
       "wfs_srs"             "EPSG:28992"
-      "wfs_abstract"        "Gevaarlijke stoffen"
+      "wfs_abstract"        "routes-gevaarlijke-stoffen"
       "wfs_enable_request"  "*"
       "gml_featureid"       "name"
       "gml_include_items"   "all"
-      "wms_title"           "Gevaarlijke stoffen"
+      "wms_title"           "routes-gevaarlijke-stoffen"
       "wms_enable_request"  "*"
       "wms_group_title"     "wegenbestand"
-      "wms_abstract"        "Gevaarlijke stoffen"
+      "wms_abstract"        "routes-gevaarlijke-stoffen"
       "wms_srs"             "EPSG:28992"
-      "wms_name"            "gevaarlijke_stoffen"
+      "wms_name"            "routes-gevaarlijke-stoffen"
       "wms_format"          "image/png"
       "wms_server_version"  "1.1.1"
       "wms_extent"          "100000 450000 150000 500000"
     END
 
     CLASS
-      NAME          "Gevaarlijke stoffen"
+      NAME          "routes-gevaarlijke-stoffen"
 
       STYLE
-          WIDTH        2
+          WIDTH        1
           COLOR        255 145 0
           OUTLINECOLOR 255 145 0
       END
@@ -201,7 +215,7 @@ MAP
 # ------------------------------------------------------------------------
 
   LAYER
-    NAME                    "tunnels"
+    NAME                    "tunnels-gevaarlijke-stoffen"
     GROUP                   "wegenbestand"
     PROJECTION
       "init=epsg:28992"
@@ -215,16 +229,16 @@ MAP
 
 
     METADATA
-      "wfs_title"           "Tunnels gevaarlijke stoffen"
+      "wfs_title"           "tunnels-gevaarlijke-stoffen"
       "wfs_srs"             "EPSG:28992"
-      "wfs_abstract"        "Tunnels gevaarlijke stoffen"
+      "wfs_abstract"        "tunnels-gevaarlijke-stoffen"
       "wfs_enable_request"  "*"
       "gml_featureid"       "name"
       "gml_include_items"   "all"
-      "wms_title"           "Tunnels gevaarlijke stoffen"
+      "wms_title"           "tunnels-gevaarlijke-stoffen"
       "wms_enable_request"  "*"
       "wms_group_title"     "wegenbestand"
-      "wms_abstract"        "Tunnels gevaarlijke stoffen"
+      "wms_abstract"        "tunnels-gevaarlijke-stoffen"
       "wms_srs"             "EPSG:28992"
       "wms_name"            "tunnels"
       "wms_format"          "image/png"
@@ -233,26 +247,13 @@ MAP
     END
 
     CLASS
-      NAME          "Tunnels gevaarlijke stoffen"
+      NAME          "tunnels-gevaarlijke-stoffen"
 
       STYLE
           SYMBOL         'cirkel_oranje_tunnel'
           SIZE           16
       END
-
-      LABEL
-        MINSCALEDENOM  10
-        MAXSCALEDENOM  10000
-        COLOR          0 0 0
-        OUTLINECOLOR   255 255 255
-        OUTLINEWIDTH   3
-        FONT           "Ubuntu-MI"
-        TYPE           truetype
-        SIZE           10
-        POSITION       AUTO
-        PARTIALS       FALSE
-        OFFSET         -60 10
-      END
     END
   END
+
 END


### PR DESCRIPTION
The wegenbestand contains data about so called zones zwaar verkeer en consists of roads within that zone, outside that zone and roads that needs a special waiver to be used. These three tables all fall within the main category wegenbestand and subcategory zones zwaar verkeer.

The existing datasets hoofdroutes, like routes and tunnels gevaarlijke stoffen are also placed on the wegenbestand but not under zones zwaar verkeer. They reside on the main level in that perspective.

The current `hoofdroutes.map` (where routes and tunnels gevaarlijke stoffen are also placed) will still remain for now. It will be de-allocated when dataportaal can switch fully to the `wegenbestand.map`.