### PR TITLE
Send Access-Control-Allow-Origin for amsterdam.nl and ARCGIS Online

### DIFF
--- a/docker/000-default.conf
+++ b/docker/000-default.conf
@@ -32,5 +32,7 @@
 
   Header always set Access-Control-Allow-Methods "POST, GET, OPTIONS"
   Header always set Access-Control-Allow-Headers "Authorization, kbn-version, Origin, X-Requested-With, Content-Type, Accept, Client-Security-Token"
+  SetEnvIf Origin "https://(.*\.)?(amsterdam.nl|arcgis.com)$" ORIGIN=$0
+  Header set Access-Control-Allow-Origin %{ORIGIN}e env=ORIGIN
 
 </VirtualHost>


### PR DESCRIPTION
When I run

    docker-compose up --build
    curl -i -H "Origin: example.amsterdam.nl" http://localhost/maps/monumenten

I get an Access-Control-Allow-Origin header with example.amsterdam.nl in it.