### PR TITLE
change color ways for parkeervakken regimes that are grey

### DIFF
--- a/parkeervakken.map
+++ b/parkeervakken.map
@@ -224,14 +224,14 @@ MAP
 
       STYLE
        ANTIALIAS    true
-       OUTLINECOLOR 120 120 120 #787878
+       OUTLINECOLOR 179 139 104 #b38b68
        OPACITY      100
        WIDTH        2
       END
 
       STYLE
        ANTIALIAS    true
-       COLOR        232 232 232 #E8E8E8
+       COLOR        179 139 104 #b38b68
        OPACITY      70
        WIDTH        2
       END
@@ -244,14 +244,14 @@ MAP
 
       STYLE
        ANTIALIAS    true
-       OUTLINECOLOR 120 120 120 #787878
+       OUTLINECOLOR 135 98 69 #876245
        OPACITY      100
        WIDTH        2
       END
 
       STYLE
        ANTIALIAS    true
-       COLOR        190 190 190 #BEBEBE
+       COLOR        135 98 69 #876245
        OPACITY      70
        WIDTH        2
       END
@@ -264,14 +264,14 @@ MAP
 
       STYLE
        ANTIALIAS    true
-       OUTLINECOLOR 120 120 120 #787878
+       OUTLINECOLOR 101 73 52 #654934
        OPACITY      100
        WIDTH        2
       END
 
       STYLE
        ANTIALIAS    true
-       COLOR        120 120 120 #787878
+       COLOR        101 73 52 #654934
        OPACITY      70
        WIDTH        2
       END
@@ -284,14 +284,14 @@ MAP
 
       STYLE
        ANTIALIAS    true
-       OUTLINECOLOR 0 0 0 #000000
+       OUTLINECOLOR 179 139 104 #b38b6d
        OPACITY      100
        WIDTH        2
       END
 
       STYLE
        ANTIALIAS    true
-       COLOR        0 0 0 #000000
+       COLOR        179 139 104 #b38b6d
        OPACITY      70
        WIDTH        2
       END


### PR DESCRIPTION
On request of source maintainer, changed the colorways of `parkeervakken regimes`