### PR TITLE
Add rioolknopen layer + various fixes in ondergrond map

### DIFF
--- a/ondergrond.map
+++ b/ondergrond.map
@@ -99,8 +99,12 @@ MAP
     END
   END
   LAYER
-    NAME "kabels en leidingen - gas lage druk"
+    NAME "kabels_en_leidingen_gas_lage_druk"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - gas lage druk"
+      "wfs_title"   "kabels en leidingen - gas lage druk"
+    END
     CLASS
         NAME                 "gas lage druk"
         EXPRESSION           "gas lage druk"
@@ -111,8 +115,12 @@ MAP
     END
   END
   LAYER
-    NAME "kabels en leidingen - buisleiding gevaarlijke inhoud"
+    NAME "kabels_en_leidingen_buisleiding_gevaarlijke_inhoud"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - buisleiding gevaarlijke inhoud"
+      "wfs_title"   "kabels en leidingen - buisleiding gevaarlijke inhoud"
+    END
     CLASS
         NAME                 "buisleiding gevaarlijke inhoud"
         EXPRESSION           "buisleiding gevaarlijke inhoud"
@@ -123,8 +131,12 @@ MAP
     END
   END
   LAYER
-    NAME "kabels en leidingen - landelijk hoogspanningsnet"
+    NAME "kabels_en_leidingen_landelijk_hoogspanningsnet"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - landelijk hoogspanningsnet"
+      "wfs_title"   "kabels en leidingen - landelijk hoogspanningsnet"
+    END
     CLASS
         NAME                 "landelijk hoogspanningsnet"
         EXPRESSION           "landelijk hoogspanningsnet"
@@ -135,8 +147,12 @@ MAP
     END
   END
   LAYER
-    NAME "kabels en leidingen - hoogspanning"
+    NAME "kabels_en_leidingen_hoogspanning"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - hoogspanning"
+      "wfs_title"   "kabels en leidingen - hoogspanning"
+    END
     CLASS
         NAME                 "hoogspanning"
         EXPRESSION           "hoogspanning"
@@ -147,8 +163,12 @@ MAP
     END
   END
   LAYER
-    NAME "kabels en leidingen - middenspanning"
+    NAME "kabels_en_leidingen_middenspanning"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - middenspanning"
+      "wfs_title"   "kabels en leidingen - middenspanning"
+    END
     CLASS
         NAME                 "middenspanning"
         EXPRESSION           "middenspanning"
@@ -159,8 +179,12 @@ MAP
     END
   END
   LAYER
-    NAME "kabels en leidingen - laagspanning"
+    NAME "kabels_en_leidingen_laagspanning"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - laagspanning"
+      "wfs_title"   "kabels en leidingen - laagspanning"
+    END
     CLASS
         NAME                 "laagspanning"
         EXPRESSION           "laagspanning"
@@ -171,8 +195,12 @@ MAP
     END
   END
   LAYER
-    NAME "kabels en leidingen - chemie"
+    NAME "kabels_en_leidingen_chemie"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - chemie"
+      "wfs_title"   "kabels en leidingen - chemie"
+    END
     CLASS
         NAME                 "(petro)chemie"
         EXPRESSION           "(petro)chemie"
@@ -183,8 +211,12 @@ MAP
     END
   END
   LAYER
-    NAME "kabels en leidingen - riool vrijverval"
+    NAME "kabels_en_leidingen_riool_vrijverval"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - rioolvrijverval"
+      "wfs_title"   "kabels en leidingen - rioolvrijverval"
+    END
     CLASS
         NAME                 "riool vrijverval"
         EXPRESSION           "riool vrijverval"
@@ -195,8 +227,12 @@ MAP
     END
   END
   LAYER
-    NAME                 "kabels en leidingen - riool onder over- of onderdruk"
+    NAME                 "kabels_en_leidingen_riool_over_of_onderdruk"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - riool over- of onderdruk"
+      "wfs_title"   "kabels en leidingen - riool over- of onderdruk"
+    END
     CLASS
         NAME                 "riool onder over- of onderdruk"
         EXPRESSION           "riool onder over- of onderdruk"
@@ -207,8 +243,12 @@ MAP
     END
   END
   LAYER
-    NAME "kabels en leidingen - warmte"
+    NAME "kabels_en_leidingen_warmte"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - warmte"
+      "wfs_title"   "kabels en leidingen - warmte"
+    END
     CLASS
         NAME                 "warmte"
         EXPRESSION           "warmte"
@@ -219,8 +259,12 @@ MAP
     END
   END
   LAYER
-    NAME "kabels en leidingen - water"
+    NAME "kabels_en_leidingen_water"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - water"
+      "wfs_title"   "kabels en leidingen - water"
+    END
     CLASS
         NAME                 "water"
         EXPRESSION           "water"
@@ -231,8 +275,12 @@ MAP
     END
   END
   LAYER
-    NAME "kabels en leidingen - wees"
+    NAME "kabels_en_leidingen_wees"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - wees"
+      "wfs_title"   "kabels en leidingen - wees"
+    END
     CLASS
         NAME                 "wees"
         EXPRESSION           "wees"
@@ -243,8 +291,12 @@ MAP
     END
   END
   LAYER
-    NAME "kabels en leidingen - overig"
+    NAME "kabels_en_leidingen_overig"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - overig"
+      "wfs_title"   "kabels en leidingen - overig"
+    END
     CLASS
         NAME                 "overig"
         EXPRESSION           "overig"
@@ -257,8 +309,12 @@ MAP
 
   # --------------------- OBJECTEN ----------------------
   LAYER
-    NAME "objecten - datatransport"
+    NAME "objecten_datatransport"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - datatransport"
+      "wfs_title"   "objecten - datatransport"
+    END
 
     CLASS
         NAME                 "datatransport"
@@ -271,8 +327,12 @@ MAP
     END
   END
   LAYER
-    NAME "objecten - gas hoge druk"
+    NAME "objecten_gas_hoge_druk"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - gas hoge druk"
+      "wfs_title"   "objecten - gas hoge druk"
+    END
     CLASS
         NAME                 "gas hoge druk"
         EXPRESSION           "gas hoge druk"
@@ -284,8 +344,12 @@ MAP
     END
   END
   LAYER
-    NAME "objecten - gas lage druk"
+    NAME "objecten_gas_lage_druk"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - gas lage druk"
+      "wfs_title"   "objecten - gas lage druk"
+    END
     CLASS
         NAME                 "gas lage druk"
         EXPRESSION           "gas lage druk"
@@ -297,8 +361,12 @@ MAP
     END
   END
   LAYER
-    NAME "objecten - buisleiding gevaarlijke inhoud"
+    NAME "objecten_buisleiding_gevaarlijke_inhoud"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - buisleiding gevaarlijke inhoud"
+      "wfs_title"   "objecten - buisleiding gevaarlijke inhoud"
+    END
     CLASS
         NAME                 "buisleiding gevaarlijke inhoud"
         EXPRESSION           "buisleiding gevaarlijke inhoud"
@@ -310,8 +378,12 @@ MAP
     END
   END
   LAYER
-    NAME "objecten - landelijk hoogspanningsnet"
+    NAME "objecten_landelijk_hoogspanningsnet"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - landelijk hoogspanningsnet"
+      "wfs_title"   "objecten - landelijk hoogspanningsnet"
+    END
     CLASS
         NAME                 "landelijk hoogspanningsnet"
         EXPRESSION           "landelijk hoogspanningsnet"
@@ -323,10 +395,11 @@ MAP
     END
   END
   LAYER
-    NAME "objecten - hoogspanning"
+    NAME "objecten_hoogspanning"
     INCLUDE "ondergrond/objecten_layer.inc"
     METADATA
-      "wms_title"   "stinkie"
+      "wms_title"   "objecten - hoogspanning"
+      "wfs_title"   "objecten - hoogspanning"
     END
     CLASS
         NAME                 "hoogspanning"
@@ -339,8 +412,12 @@ MAP
     END
   END
   LAYER
-    NAME "objecten - middenspanning"
+    NAME "objecten_middenspanning"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - middenspanning"
+      "wfs_title"   "objecten - middenspanning"
+    END
     CLASS
         NAME                 "middenspanning"
         EXPRESSION           "middenspanning"
@@ -352,8 +429,12 @@ MAP
     END
   END
   LAYER
-    NAME "objecten - laagspanning"
+    NAME "objecten_laagspanning"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - laagspanning"
+      "wfs_title"   "objecten - laagspanning"
+    END
     CLASS
         NAME                 "laagspanning"
         EXPRESSION           "laagspanning"
@@ -365,8 +446,12 @@ MAP
     END
   END
   LAYER
-    NAME "objecten - chemie"
+    NAME "objecten_chemie"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - chemie"
+      "wfs_title"   "objecten - chemie"
+    END
     CLASS
         NAME                 "(petro)chemie"
         EXPRESSION           "(petro)chemie"
@@ -378,8 +463,12 @@ MAP
     END
   END
   LAYER
-    NAME "objecten - riool vrijverval"
+    NAME "objecten_riool_vrijverval"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - riool vrijverval"
+      "wfs_title"   "objecten - riool vrijverval"
+    END
     CLASS
         NAME                 "riool vrijverval"
         EXPRESSION           "riool vrijverval"
@@ -391,8 +480,12 @@ MAP
     END
   END
   LAYER
-    NAME                 "objecten - riool onder over- of onderdruk"
+    NAME                 "objecten_riool_over_of_onderdruk"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - riool over- of onderdruk"
+      "wfs_title"   "objecten - riool over- of onderdruk"
+    END
     CLASS
         NAME                 "riool onder over- of onderdruk"
         EXPRESSION           "riool onder over- of onderdruk"
@@ -404,8 +497,12 @@ MAP
     END
   END
   LAYER
-    NAME "objecten - warmte"
+    NAME "objecten_warmte"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - warmte"
+      "wfs_title"   "objecten - warmte"
+    END
     CLASS
         NAME                 "warmte"
         EXPRESSION           "warmte"
@@ -417,8 +514,12 @@ MAP
     END
   END
   LAYER
-    NAME "objecten - water"
+    NAME "objecten_water"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - water"
+      "wfs_title"   "objecten - water"
+    END
     CLASS
         NAME                 "water"
         EXPRESSION           "water"
@@ -430,8 +531,12 @@ MAP
     END
   END
   LAYER
-    NAME "objecten - wees"
+    NAME "objecten_wees"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - wees"
+      "wfs_title"   "objecten - wees"
+    END
     CLASS
         NAME                 "wees"
         EXPRESSION           "wees"
@@ -443,8 +548,12 @@ MAP
     END
   END
   LAYER
-    NAME "objecten - overig"
+    NAME "objecten_overig"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "objecten - overig"
+      "wfs_title"   "objecten - overig"
+    END
     CLASS
         NAME                 "overig"
         EXPRESSION           "overig"
@@ -459,8 +568,12 @@ MAP
   # --------------------- EISVOORZORGSMAATREGELEN ----------------------
   
   LAYER
-    NAME "eisvoorzorgsmaatregelen - datatransport"
+    NAME "eisvoorzorgsmaatregelen_datatransport"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - datatransport"
+      "wfs_title"   "eisvoorzorgsmaatregelen - datatransport"
+    END
 
     CLASS
         NAME                 "datatransport"
@@ -472,8 +585,12 @@ MAP
     END
   END
   LAYER
-    NAME "eisvoorzorgsmaatregelen - gas hoge druk"
+    NAME "eisvoorzorgsmaatregelen_gas_hoge_druk"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - gas hoge druk"
+      "wfs_title"   "eisvoorzorgsmaatregelen - gas hoge druk"
+    END
     CLASS
         NAME                 "gas hoge druk"
         EXPRESSION           "gas hoge druk"
@@ -484,8 +601,13 @@ MAP
     END
   END
   LAYER
-    NAME "eisvoorzorgsmaatregelen - gas lage druk"
+    NAME "eisvoorzorgsmaatregelen_gas_lage_druk"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - gas lage druk"
+      "wfs_title"   "eisvoorzorgsmaatregelen - gas lage druk"
+    END
+
     CLASS
         NAME                 "gas lage druk"
         EXPRESSION           "gas lage druk"
@@ -496,8 +618,13 @@ MAP
     END
   END
   LAYER
-    NAME "eisvoorzorgsmaatregelen - buisleiding gevaarlijke inhoud"
+    NAME "eisvoorzorgsmaatregelen_buisleiding_gevaarlijke_inhoud"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - buisleiding gevaarlijke inhoud"
+      "wfs_title"   "eisvoorzorgsmaatregelen - buisleiding gevaarlijke inhoud"
+    END
+
     CLASS
         NAME                 "buisleiding gevaarlijke inhoud"
         EXPRESSION           "buisleiding gevaarlijke inhoud"
@@ -508,8 +635,13 @@ MAP
     END
   END
   LAYER
-    NAME "eisvoorzorgsmaatregelen - landelijk hoogspanningsnet"
+    NAME "eisvoorzorgsmaatregelen_landelijk_hoogspanningsnet"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - landelijk hoogspanningsnet"
+      "wfs_title"   "eisvoorzorgsmaatregelen - landelijk hoogspanningsnet"
+    END
+
     CLASS
         NAME                 "landelijk hoogspanningsnet"
         EXPRESSION           "landelijk hoogspanningsnet"
@@ -520,8 +652,13 @@ MAP
     END
   END
   LAYER
-    NAME "eisvoorzorgsmaatregelen - hoogspanning"
+    NAME "eisvoorzorgsmaatregelen_hoogspanning"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - hoogspanning"
+      "wfs_title"   "eisvoorzorgsmaatregelen - hoogspanning"
+    END
+  
     CLASS
         NAME                 "hoogspanning"
         EXPRESSION           "hoogspanning"
@@ -532,8 +669,13 @@ MAP
     END
   END
   LAYER
-    NAME "eisvoorzorgsmaatregelen - middenspanning"
+    NAME "eisvoorzorgsmaatregelen_middenspanning"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - middenspanning"
+      "wfs_title"   "eisvoorzorgsmaatregelen - middenspanning"
+    END
+  
     CLASS
         NAME                 "middenspanning"
         EXPRESSION           "middenspanning"
@@ -544,8 +686,13 @@ MAP
     END
   END
   LAYER
-    NAME "eisvoorzorgsmaatregelen - laagspanning"
+    NAME "eisvoorzorgsmaatregelen_laagspanning"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - laagspanning"
+      "wfs_title"   "eisvoorzorgsmaatregelen - laagspanning"
+    END
+  
     CLASS
         NAME                 "laagspanning"
         EXPRESSION           "laagspanning"
@@ -556,8 +703,13 @@ MAP
     END
   END
   LAYER
-    NAME "eisvoorzorgsmaatregelen - chemie"
+    NAME "eisvoorzorgsmaatregelen_chemie"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - chemie"
+      "wfs_title"   "eisvoorzorgsmaatregelen - chemie"
+    END
+  
     CLASS
         NAME                 "(petro)chemie"
         EXPRESSION           "(petro)chemie"
@@ -568,8 +720,13 @@ MAP
     END
   END
   LAYER
-    NAME "eisvoorzorgsmaatregelen - riool vrijverval"
+    NAME "eisvoorzorgsmaatregelen_riool_vrijverval"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - riool vrijverval"
+      "wfs_title"   "eisvoorzorgsmaatregelen - riool vrijverval"
+    END
+  
     CLASS
         NAME                 "riool vrijverval"
         EXPRESSION           "riool vrijverval"
@@ -580,8 +737,13 @@ MAP
     END
   END
   LAYER
-    NAME                 "eisvoorzorgsmaatregelen - riool onder over- of onderdruk"
+    NAME                 "eisvoorzorgsmaatregelen_riool_over_of_onderdruk"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - riool over- of onderdruk"
+      "wfs_title"   "eisvoorzorgsmaatregelen - riool over- of onderdruk"
+    END
+  
     CLASS
         NAME                 "riool onder over- of onderdruk"
         EXPRESSION           "riool onder over- of onderdruk"
@@ -592,8 +754,13 @@ MAP
     END
   END
   LAYER
-    NAME "eisvoorzorgsmaatregelen - warmte"
+    NAME "eisvoorzorgsmaatregelen_warmte"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - warmte"
+      "wfs_title"   "eisvoorzorgsmaatregelen - warmte"
+    END
+  
     CLASS
         NAME                 "warmte"
         EXPRESSION           "warmte"
@@ -604,8 +771,13 @@ MAP
     END
   END
   LAYER
-    NAME "eisvoorzorgsmaatregelen - water"
+    NAME "eisvoorzorgsmaatregelen_water"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - water"
+      "wfs_title"   "eisvoorzorgsmaatregelen - water"
+    END
+  
     CLASS
         NAME                 "water"
         EXPRESSION           "water"
@@ -616,8 +788,13 @@ MAP
     END
   END
   LAYER
-    NAME "eisvoorzorgsmaatregelen - wees"
+    NAME "eisvoorzorgsmaatregelen_wees"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - wees"
+      "wfs_title"   "eisvoorzorgsmaatregelen - wees"
+    END
+  
     CLASS
         NAME                 "wees"
         EXPRESSION           "wees"
@@ -628,8 +805,13 @@ MAP
     END
   END
   LAYER
-    NAME "eisvoorzorgsmaatregelen - overig"
+    NAME "eisvoorzorgsmaatregelen_overig"
     INCLUDE "ondergrond/eisvoorzorgsmaatregelen_layer.inc"
+    METADATA
+      "wms_title"   "eisvoorzorgsmaatregelen - overig"
+      "wfs_title"   "eisvoorzorgsmaatregelen - overig"
+    END
+  
     CLASS
         NAME                 "overig"
         EXPRESSION           "overig"

--- a/ondergrond.map
+++ b/ondergrond.map
@@ -18,16 +18,16 @@ MAP
   #-----------------------------------------------------------------------------
   # Layers
   #-----------------------------------------------------------------------------
+  
+  # --------------------- HISTORISCHE ONDERZOEKEN ----------------------
 
   LAYER
     NAME                    "historische_onderzoeken"
-
     DATA                    "geometrie FROM ondergrond_historischeonderzoeken USING srid=28992 USING UNIQUE id"
-    PROCESSING "CLOSE_CONNECTION=DEFER" # Use the same connection for all queried layers because they reside in the same db
+    PROCESSING              "CLOSE_CONNECTION=DEFER" # Use the same connection for all queried layers because they reside in the same db
     TYPE                    POLYGON
     MINSCALEDENOM           10
     MAXSCALEDENOM           400000
-
 
     METADATA
       "wfs_title"           "Historische onderzoeken"
@@ -66,8 +66,12 @@ MAP
   # --------------------- KABELS EN LEIDINGEN ----------------------
 
   LAYER
-    NAME "kabels en leidingen - datatransport"
+    NAME "kabels_en_leidingen_datatransport"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - datatransport"
+      "wfs_title"   "kabels en leidingen - datatransport"
+    END
 
     CLASS
         NAME                 "datatransport"
@@ -79,8 +83,12 @@ MAP
     END
   END
   LAYER
-    NAME "kabels en leidingen - gas hoge druk"
+    NAME "kabels_en_leidingen_gas_hoge_druk"
     INCLUDE "ondergrond/kabels_en_leidingen_layer.inc"
+    METADATA
+      "wms_title"   "kabels en leidingen - gas hoge druk"
+      "wfs_title"   "kabels en leidingen - gas hoge druk"
+    END
     CLASS
         NAME                 "gas hoge druk"
         EXPRESSION           "gas hoge druk"
@@ -317,6 +325,9 @@ MAP
   LAYER
     NAME "objecten - hoogspanning"
     INCLUDE "ondergrond/objecten_layer.inc"
+    METADATA
+      "wms_title"   "stinkie"
+    END
     CLASS
         NAME                 "hoogspanning"
         EXPRESSION           "hoogspanning"
@@ -626,6 +637,49 @@ MAP
             COLOR        "#6f5c10"
             SIZE 5
         END
+    END
+  END
+
+  # ------------------------- RIOOLKNOPEN ---------------------------[
+  LAYER
+    NAME                    "rioolknopen"
+    DATA                    "geometrie FROM leidingeninfrastructuur_waternet_rioolknopen USING srid=7415 USING UNIQUE id"
+    PROCESSING              "CLOSE_CONNECTION=DEFER" # Use the same connection for all queried layers because they reside in the same db
+    TYPE                    POLYGON
+    MINSCALEDENOM           10
+    MAXSCALEDENOM           400000
+
+    METADATA
+      "wfs_title"           "Historische onderzoeken"
+      "wfs_srs"             "EPSG:28992"
+      "wfs_abstract"        "Historische onderzoeken Amsterdam"
+      "wfs_enable_request"  "*"
+      "gml_featureid"       "id"
+      "gml_include_items"   "all"
+      "wms_title"           "Historische onderzoeken"
+      "wms_enable_request"  "*"
+      "wms_abstract"        "Historische onderzoeken Amsterdam"
+      "wms_srs"             "EPSG:28992"
+      "wms_name"            "Historische onderzoeken"
+      "wms_format"          "image/png"
+      "wms_server_version"  "1.1.1"
+      "wms_extent"          "100000 450000 150000 500000"
+    END
+
+    LABELITEM               "id"
+
+    CLASS
+        NAME                 "historische onderzoeken"
+            STYLE
+                ANTIALIAS    true
+                COLOR        0 153 0
+                OPACITY      60
+            END
+            STYLE
+                OUTLINECOLOR  0 153 0
+                OPACITY      100
+                WIDTH        1
+            END
     END
   END
 

--- a/ondergrond.map
+++ b/ondergrond.map
@@ -23,6 +23,7 @@ MAP
 
   LAYER
     NAME                    "historische_onderzoeken"
+    INCLUDE                 "connection_dataservices.inc"
     DATA                    "geometrie FROM ondergrond_historischeonderzoeken USING srid=28992 USING UNIQUE id"
     PROCESSING              "CLOSE_CONNECTION=DEFER" # Use the same connection for all queried layers because they reside in the same db
     TYPE                    POLYGON
@@ -825,24 +826,25 @@ MAP
   # ------------------------- RIOOLKNOPEN ---------------------------[
   LAYER
     NAME                    "rioolknopen"
+    INCLUDE                 "connection_dataservices.inc"
     DATA                    "geometrie FROM leidingeninfrastructuur_waternet_rioolknopen USING srid=7415 USING UNIQUE id"
     PROCESSING              "CLOSE_CONNECTION=DEFER" # Use the same connection for all queried layers because they reside in the same db
-    TYPE                    POLYGON
+    TYPE                    POINT
     MINSCALEDENOM           10
     MAXSCALEDENOM           400000
 
     METADATA
-      "wfs_title"           "Historische onderzoeken"
+      "wfs_title"           "Rioolknopen"
       "wfs_srs"             "EPSG:28992"
-      "wfs_abstract"        "Historische onderzoeken Amsterdam"
+      "wfs_abstract"        "Rioolknopen Waternet"
       "wfs_enable_request"  "*"
       "gml_featureid"       "id"
       "gml_include_items"   "all"
-      "wms_title"           "Historische onderzoeken"
+      "wms_title"           "Rioolknopen Waternet"
       "wms_enable_request"  "*"
-      "wms_abstract"        "Historische onderzoeken Amsterdam"
+      "wms_abstract"        "Rioolknopen Waternet"
       "wms_srs"             "EPSG:28992"
-      "wms_name"            "Historische onderzoeken"
+      "wms_name"            "Rioolknopen Waternet"
       "wms_format"          "image/png"
       "wms_server_version"  "1.1.1"
       "wms_extent"          "100000 450000 150000 500000"
@@ -851,17 +853,12 @@ MAP
     LABELITEM               "id"
 
     CLASS
-        NAME                 "historische onderzoeken"
-            STYLE
-                ANTIALIAS    true
-                COLOR        0 153 0
-                OPACITY      60
-            END
-            STYLE
-                OUTLINECOLOR  0 153 0
-                OPACITY      100
-                WIDTH        1
-            END
+        NAME                 "rioolknopen"
+        STYLE
+            SYMBOL "stip"
+            COLOR        "#ff0000"
+            SIZE 5
+        END
     END
   END
 

--- a/ondergrond/eisvoorzorgsmaatregelen_layer.inc
+++ b/ondergrond/eisvoorzorgsmaatregelen_layer.inc
@@ -7,18 +7,18 @@
     TYPE                    POLYGON
 
     METADATA
-      "wfs_group_title"     "Eisvoorzorgsmaatregelen Kadaster:"
+      "wfs_group_title"     "Eisvoorzorgsmaatregelen Kadaster"
       "wfs_srs"             "EPSG:28992"
-      "wfs_group_abstract"  "Eisvoorzorgsmaatregelen Kadaster:"
+      "wfs_group_abstract"  "Eisvoorzorgsmaatregelen Kadaster"
       "wfs_enable_request"  "*"
       "wfs_extent"          "110000 476000 169999 52000"
       "gml_featureid"       "id"
       "gml_include_items"   "all"
-      "wms_group_title"     "Eisvoorzorgsmaatregelen Kadaster:"
+      "wms_group_title"     "Eisvoorzorgsmaatregelen Kadaster"
       "wms_enable_request"  "*"
       "wms_group_abstract"  ""
       "wms_srs"             "EPSG:28992"
-      "wms_group_name"      "Eisvoorzorgsmaatregelen Kadaster:"
+      "wms_group_name"      "Eisvoorzorgsmaatregelen Kadaster"
       "wms_format"          "image/png"
       "wms_server_version"  "1.1.1"
       "wms_extent"          "110000 476000 169999 52000"

--- a/ondergrond/eisvoorzorgsmaatregelen_layer.inc
+++ b/ondergrond/eisvoorzorgsmaatregelen_layer.inc
@@ -2,7 +2,7 @@
 
     INCLUDE                 "connection_dataservices.inc"
     DATA                    "geometrie FROM leidingeninfrastructuur_ligging_vlak_totaal USING srid=28992 USING UNIQUE id"
-    EXTENT                  110000 476000 169999 520000
+    #EXTENT                  110000 476000 169999 520000
     PROCESSING              "CLOSE_CONNECTION=DEFER"
     TYPE                    POLYGON
 
@@ -21,7 +21,7 @@
       "wms_group_name"      "Eisvoorzorgsmaatregelen Kadaster"
       "wms_format"          "image/png"
       "wms_server_version"  "1.1.1"
-      "wms_extent"          "110000 476000 169999 52000"
+      #"wms_extent"          "110000 476000 169999 52000"
     END
 
     LABELITEM               "thema"

--- a/ondergrond/kabels_en_leidingen_layer.inc
+++ b/ondergrond/kabels_en_leidingen_layer.inc
@@ -6,7 +6,7 @@
     PROCESSING "CLOSE_CONNECTION=DEFER" # Use the same connection for all queried layers because they reside in the same db
     TYPE                    LINE
     MAXSCALEDENOM 20000
-        METADATA
+    METADATA
       "wfs_group_title"           "Kabels en Leidingen Kadaster"
       "wfs_srs"             "EPSG:28992"
       "wfs_group_abstract"        "Kabels en Leidingen Kadaster"


### PR DESCRIPTION
implements 52384 partially (rioolleidingen remains todo)

- fixes historische_onderzoeken (broken for a long time :s)
- fixes eisvoorzorgsmaatregelen (layer extent was outside map extent)
- proper titles and names for kabelsleidingen, objecten and eisvoorzorgsmaatregelen