### PR TITLE
Inject the URL for the lufo layers from environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,6 @@ services:
       DATASERVICES_DB_PASSWORD: insecure
       DATASERVICES_DB_HOST: database
 
-      MAP_URL: "http://mapserver"
-      LEGEND_URL: "http://mapserver"
+      MAP_URL: "http://map"
+      LEGEND_URL: "http://map"
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -134,7 +134,7 @@ sed -i 's/ErrorLog .*/ErrorLog \/dev\/stderr/' /etc/apache2/apache2.conf
 sed -i 's/Timeout 300/Timeout 600/' /etc/apache2/apache2.conf
 
 # Replace actual location of the mapserver depending on the environment
-sed -i 's#MAP_URL_REPLACE#'"$MAP_URL"'#g' /srv/mapserver/topografie.map /srv/mapserver/topografie_wm.map
+sed -i 's#MAP_URL_REPLACE#'"$MAP_URL"'#g' /srv/mapserver/topografie.map /srv/mapserver/topografie_wm.map /srv/mapserver/lufo.map
 sed -i 's#LEGEND_URL_REPLACE#'"$LEGEND_URL"'#g' /srv/mapserver/topografie.map /srv/mapserver/topografie_wm.map
 
 mkdir -p /srv/mapserver/config

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -134,7 +134,7 @@ sed -i 's/ErrorLog .*/ErrorLog \/dev\/stderr/' /etc/apache2/apache2.conf
 sed -i 's/Timeout 300/Timeout 600/' /etc/apache2/apache2.conf
 
 # Replace actual location of the mapserver depending on the environment
-sed -i 's#MAP_URL_REPLACE#'"$MAP_URL"'#g' /srv/mapserver/topografie.map /srv/mapserver/topografie_wm.map /srv/mapserver/lufo.map
+sed -i 's#MAP_URL_REPLACE#'"$MAP_URL"'#g' /srv/mapserver/topografie.map /srv/mapserver/topografie_wm.map /srv/mapserver/lufo.map /srv/mapserver/infrarood.map
 sed -i 's#LEGEND_URL_REPLACE#'"$LEGEND_URL"'#g' /srv/mapserver/topografie.map /srv/mapserver/topografie_wm.map
 
 mkdir -p /srv/mapserver/config

--- a/infrarood.map
+++ b/infrarood.map
@@ -31,7 +31,7 @@ MAP
   LAYER
     NAME                    "infrarood2021"
     GROUP                   "infrarood"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/infrarood2021"
+    CONNECTION              "MAP_URL_REPLACE/maps/infrarood2021"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -54,7 +54,7 @@ MAP
   LAYER
     NAME                    "infrarood2020"
     GROUP                   "infrarood"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/infrarood2020"
+    CONNECTION              "MAP_URL_REPLACE/maps/infrarood2020"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -77,7 +77,7 @@ MAP
   LAYER
     NAME                    "infrarood2018"
     GROUP                   "infrarood"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/infrarood2018"
+    CONNECTION              "MAP_URL_REPLACE/maps/infrarood2018"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION

--- a/lufo.map
+++ b/lufo.map
@@ -31,7 +31,7 @@ MAP
   LAYER
     NAME                    "lufo2022"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2022"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2022"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -53,7 +53,7 @@ MAP
   LAYER
     NAME                    "lufo2021"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2021"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2021"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -75,7 +75,7 @@ MAP
   LAYER
     NAME                    "lufo2020"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2020"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2020"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -98,7 +98,7 @@ MAP
   LAYER
     NAME                    "lufo2019"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2019"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2019"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -121,7 +121,7 @@ MAP
   LAYER
     NAME                    "lufo2018"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2018"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2018"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -144,7 +144,7 @@ MAP
   LAYER
     NAME                    "lufo2017"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2017"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2017"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -167,7 +167,7 @@ MAP
   LAYER
     NAME                    "lufo2016"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2016"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2016"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -190,7 +190,7 @@ MAP
   LAYER
     NAME                    "lufo2015"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2015"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2015"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -213,7 +213,7 @@ MAP
   LAYER
     NAME                    "lufo2014"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2014"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2014"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -236,7 +236,7 @@ MAP
   LAYER
     NAME                    "lufo2013"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2013"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2013"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -259,7 +259,7 @@ MAP
   LAYER
     NAME                    "lufo2012"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2012"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2012"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -282,7 +282,7 @@ MAP
   LAYER
     NAME                    "lufo2011"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2011"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2011"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -305,7 +305,7 @@ MAP
   LAYER
     NAME                    "lufo2010"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2010"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2010"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -328,7 +328,7 @@ MAP
   LAYER
     NAME                    "lufo2009"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2009"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2009"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -351,7 +351,7 @@ MAP
   LAYER
     NAME                    "lufo2008"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2008"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2008"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -374,7 +374,7 @@ MAP
   LAYER
     NAME                    "lufo2007"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2007"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2007"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -397,7 +397,7 @@ MAP
   LAYER
     NAME                    "lufo2006"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2006"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2006"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -420,7 +420,7 @@ MAP
   LAYER
     NAME                    "lufo2005"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2005"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2005"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -443,7 +443,7 @@ MAP
   LAYER
     NAME                    "lufo2004"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2004"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2004"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION
@@ -466,7 +466,7 @@ MAP
   LAYER
     NAME                    "lufo2003"
     GROUP                   "lufo"
-    CONNECTION              "https://map.data.amsterdam.nl/maps/lufo2003"
+    CONNECTION              "MAP_URL_REPLACE/maps/lufo2003"
     CONNECTIONTYPE          WMS
     TYPE                    RASTER
     PROJECTION


### PR DESCRIPTION
This is now hardcoded, which causes problems when testing new stuff that isnt available in prod yet. The OpenStack repo sets MAP_URL_REPLACE  to `http://localhost:80` 