### PR TITLE
Equalize header.inc and private/header.inc

### DIFF
--- a/header.inc
+++ b/header.inc
@@ -1,6 +1,5 @@
 #==============================================================================
 #
-# header.map
 # doel: algemene header-informatie dat voor alle map-bestanden gelijk is.
 #
 #==============================================================================
@@ -11,13 +10,13 @@
   # MAP: debug
   #=============================================================================
 
-  # CONFIG   "MS_ERRORFILE" "/srv/mapserver/ms_error.txt"
+  #CONFIG   "MS_ERRORFILE" "/srv/mapserver/ms_error.txt"
 
   # Redirect errors to apache errorstream
   # ENABLE for debugging purposes - quite spammy
   # CONFIG   "MS_ERRORFILE" stderr
 
-  # DEBUG    5
+  #DEBUG    5
   # For errors from underlying GDAL (shows SQL query issues) -- is spammy
   # CONFIG "CPL_DEBUG" "ON"
   # CONFIG "PROJ_DEBUG" "ON"
@@ -78,8 +77,9 @@
   DEFRESOLUTION                      91
 
   PROJECTION
-     "init=epsg:28992"
+    "init=epsg:28992"
   END
+
 
   #-------------------------------------------------------------------
   # UITVOERFORMATEN

--- a/private/header.inc
+++ b/private/header.inc
@@ -1,13 +1,6 @@
 #==============================================================================
 #
-# header.map
 # doel: algemene header-informatie dat voor alle map-bestanden gelijk is.
-#
-#==============================================================================
-#
-# naam                  datum         wijziging
-# ------------------    ----------    -----------------------------------------
-# Rob Kromwijk          07-09-2015    schepping
 #
 #==============================================================================
 
@@ -59,8 +52,8 @@
       # verplicht om aan de OGC standaard te voldoen:
       "ows_contactorganization"      "gemeente Amsterdam"
       "ows_contactperson"            "Basisinformatie"
-
     END
+
     IMAGEPATH                        "/srv/mapserver/tmp_img/"
     IMAGEURL                         "/ms_tmp/"
     BROWSEFORMAT                     "image/svg+xml"
@@ -84,14 +77,14 @@
   # UITVOERFORMATEN
   #-------------------------------------------------------------------
 
-OUTPUTFORMAT
-   NAME           png
-   DRIVER         "AGG/PNG"
-   MIMETYPE       "image/png"
-   IMAGEMODE      RGB
-   EXTENSION      "png"
-   FORMATOPTION   "INTERLACE=OFF"
-   FORMATOPTION   "QUANTIZE_FORCE=ON"
+  OUTPUTFORMAT
+    NAME           png
+    DRIVER         "AGG/PNG"
+    MIMETYPE       "image/png"
+    IMAGEMODE      RGB
+    EXTENSION      "png"
+    FORMATOPTION   "INTERLACE=OFF"
+    FORMATOPTION   "QUANTIZE_FORCE=ON"
   END
 
   OUTPUTFORMAT
@@ -145,7 +138,6 @@ OUTPUTFORMAT
     IMAGEMODE   RGB
     EXTENSION   "kmz"
   END
-
 
   OUTPUTFORMAT
     NAME           shapezip


### PR DESCRIPTION
The diff between the two is now readable again.

XXX For some reason, the EXTENTs are different. They were both last changed with no reason in the commit message, so I left them as they were. Relevant commits:

12114a636af23384ab369bc1baa520d0b01ad8f0
046ee51dc1a8c6b01a634343887c57b44eca2569
3313801ca7b34c3572eb4b201cf45b1279e8730a