### PR TITLE
Serve index.json at /maps/index.json

### DIFF
--- a/docker/000-default.conf
+++ b/docker/000-default.conf
@@ -20,6 +20,7 @@
   RewriteRule ^(.*)$ $1 [R=200,L]
 
   RewriteEngine On
+  RewriteRule /maps/index.json /srv/mapserver/index.json
   RewriteRule /maps/(.+) /cgi-bin/mapserv?map=/srv/mapserver/$1.map    [QSA,PT]
   ScriptAlias /cgi-bin/ /usr/lib/cgi-bin/
   <Directory "/usr/lib/cgi-bin">


### PR DESCRIPTION
The previous location, `/index.json` was captured and turned into a 404 by some proxy in front of us at deployment time. Just changing the URL is the easiest solution. For AB#80357.