### PR TITLE
Add named classes to adresserbare objecten to make GetLegendGraphic work

### DIFF
--- a/adresseerbare_objecten.map
+++ b/adresseerbare_objecten.map
@@ -19,6 +19,7 @@ MAP
             "default_grouptitle" "gebruiksdoel"
         END
         CLASS
+            NAME "verblijfsobjecten_kantoorfunctie"
             STYLE
                 SYMBOL "stip"
                 COLOR "#ff0000"
@@ -40,6 +41,7 @@ MAP
             "default_grouptitle" "gebruiksdoel"
         END
         CLASS
+            NAME "verblijfsobjecten_woonfunctie"
             STYLE
                 SYMBOL "stip"
                 COLOR "#ff0000"
@@ -58,6 +60,7 @@ MAP
             "default_grouptitle" "gebruiksdoel"
         END
         CLASS
+            NAME "verblijfsobjecten_bijeenkomstfunctie"
             STYLE
                 SYMBOL "stip"
                 COLOR "#924900"
@@ -76,6 +79,7 @@ MAP
             "default_grouptitle" "gebruiksdoel"
         END
         CLASS
+            NAME "verblijfsobjecten_winkelfunctie"
             STYLE
                 SYMBOL "stip"
                 COLOR "#ffff00"
@@ -94,6 +98,7 @@ MAP
             "default_grouptitle" "gebruiksdoel"
         END
         CLASS
+            NAME "verblijfsobjecten_gezondheidszorgfunctie"
             STYLE
                 SYMBOL "stip"
                 COLOR "#f79646"
@@ -112,6 +117,7 @@ MAP
             "default_grouptitle" "gebruiksdoel"
         END
         CLASS
+            NAME "verblijfsobjecten_industriefunctie"
             STYLE
                 SYMBOL "stip"
                 COLOR "#00b0f0"
@@ -130,6 +136,7 @@ MAP
             "default_grouptitle" "gebruiksdoel"
         END
         CLASS
+            NAME "verblijfsobjecten_celfunctie"
             STYLE
                 SYMBOL "stip"
                 COLOR "#00ffff"
@@ -148,6 +155,7 @@ MAP
             "default_grouptitle" "gebruiksdoel"
         END
         CLASS
+            NAME "verblijfsobjecten_logiesfunctie"
             STYLE
                 SYMBOL "stip"
                 COLOR "#0070c0"
@@ -166,6 +174,7 @@ MAP
             "default_grouptitle" "gebruiksdoel"
         END
         CLASS
+        NAME "verblijfsobjecten_onderwijsfunctie"
             STYLE
                 SYMBOL "stip"
                 COLOR "#ff33cc"
@@ -184,6 +193,7 @@ MAP
             "default_grouptitle" "gebruiksdoel"
         END
         CLASS
+            NAME "verblijfsobjecten_sportfunctie"
             STYLE
                 SYMBOL "stip"
                 COLOR "#92d050"
@@ -202,6 +212,7 @@ MAP
             "default_grouptitle" "gebruiksdoel"
         END
         CLASS
+            NAME "verblijfsobjecten_overige_gebruiksfunctie"
             STYLE
                 SYMBOL "stip"
                 COLOR "#dcb9aa"
@@ -219,6 +230,7 @@ MAP
             "default_layertitle" "kantoorfunctie"
         END
         CLASS
+            NAME "standplaatsen_kantoorfunctie"
             STYLE
                 COLOR "#7030a0"
             END
@@ -233,6 +245,7 @@ MAP
             "default_layertitle" "woonfunctie"
         END
         CLASS
+            NAME "standplaatsen_woonfunctie"
             STYLE
                 COLOR "#ff0000"
             END
@@ -247,6 +260,7 @@ MAP
             "default_layertitle" "bijeenkomstfunctie"
         END
         CLASS
+            NAME "standplaatsen_bijeenkomstfunctie"
             STYLE
                 COLOR "#924900"
             END
@@ -261,6 +275,7 @@ MAP
             "default_layertitle" "winkelfunctie"
         END
         CLASS
+            NAME "standplaatsen_winkelfunctie"
             STYLE
                 COLOR "#ffff00"
             END
@@ -275,6 +290,7 @@ MAP
             "default_layertitle" "gezondheidszorgfunctie"
         END
         CLASS
+            NAME "standplaatsen_gezondheidszorgfunctie"
             STYLE
                 COLOR "#f79646"
             END
@@ -289,6 +305,7 @@ MAP
             "default_layertitle" "industriefunctie"
         END
         CLASS
+            NAME "standplaatsen_industriefunctie"
             STYLE
                 COLOR "#00b0f0"
             END
@@ -303,6 +320,7 @@ MAP
             "default_layertitle" "celfunctie"
         END
         CLASS
+            NAME "standplaatsen_celfunctie"
             STYLE
                 COLOR "#00ffff"
             END
@@ -317,6 +335,7 @@ MAP
             "default_layertitle" "logiesfunctie"
         END
         CLASS
+            NAME "standplaatsen_logiesfunctie"
             STYLE
                 COLOR "#0070c0"
             END
@@ -331,6 +350,7 @@ MAP
             "default_layertitle" "onderwijsfunctie"
         END
         CLASS
+            NAME "standplaatsen_onderwijsfunctie"
             STYLE
                 COLOR "#ff33cc"
             END
@@ -345,6 +365,7 @@ MAP
             "default_layertitle" "sportfunctie"
         END
         CLASS
+            NAME "standplaatsen_sportfunctie"
             STYLE
                 COLOR "#92d050"
             END
@@ -359,6 +380,7 @@ MAP
             "default_layertitle" "overige gebruiksfunctie"
         END
         CLASS
+            NAME "standplaatsen_overige_gebruiksfunctie"
             STYLE
                 COLOR "#dcb9aa"
             END
@@ -373,6 +395,7 @@ MAP
             "default_layertitle" "kantoorfunctie"
         END
         CLASS
+            NAME "ligplaatsen_kantoorfunctie"
             STYLE
                 COLOR "#7030a0"
             END
@@ -387,6 +410,7 @@ MAP
             "default_layertitle" "woonfunctie"
         END
         CLASS
+            NAME "ligplaatsen_woonfunctie"
             STYLE
                 COLOR "#ff0000"
             END
@@ -401,6 +425,7 @@ MAP
             "default_layertitle" "bijeenkomstfunctie"
         END
         CLASS
+            NAME "ligplaatsen_bijeenkomstfunctie"
             STYLE
                 COLOR "#924900"
             END
@@ -415,6 +440,7 @@ MAP
             "default_layertitle" "winkelfunctie"
         END
         CLASS
+            NAME "ligplaatsen_winkelfunctie"
             STYLE
                 COLOR "#ffff00"
             END
@@ -429,6 +455,7 @@ MAP
             "default_layertitle" "gezondheidszorgfunctie"
         END
         CLASS
+            NAME "ligplaatsen_gezondheidszorgfunctie"
             STYLE
                 COLOR "#f79646"
             END
@@ -443,6 +470,7 @@ MAP
             "default_layertitle" "industriefunctie"
         END
         CLASS
+            NAME "ligplaatsen_industriefunctie"
             STYLE
                 COLOR "#00b0f0"
             END
@@ -457,6 +485,7 @@ MAP
             "default_layertitle" "celfunctie"
         END
         CLASS
+            NAME "ligplaatsen_celfunctie"
             STYLE
                 COLOR "#00ffff"
             END
@@ -471,6 +500,7 @@ MAP
             "default_layertitle" "logiesfunctie"
         END
         CLASS
+            NAME "ligplaatsen_logiesfunctie"
             STYLE
                 COLOR "#0070c0"
             END
@@ -485,6 +515,7 @@ MAP
             "default_layertitle" "onderwijsfunctie"
         END
         CLASS
+            NAME "ligplaatsen_onderwijsfunctie"
             STYLE
                 COLOR "#ff33cc"
             END
@@ -499,6 +530,7 @@ MAP
             "default_layertitle" "sportfunctie"
         END
         CLASS
+            NAME "ligplaatsen_sportfunctie"
             STYLE
                 COLOR "#92d050"
             END
@@ -513,6 +545,7 @@ MAP
             "default_layertitle" "overige gebruiksfunctie"
         END
         CLASS
+            NAME "ligplaatsen_overige_gebruiksfunctie"
             STYLE
                 COLOR "#dcb9aa"
             END
@@ -531,6 +564,7 @@ MAP
             "default_grouptitle" "status"
         END
         CLASS
+            NAME "verblijfsobjecten_verblijfsobject_ten_onrechte_opgevoerd"
             STYLE
                 SYMBOL "stip"
                 COLOR "#ff0000"
@@ -549,6 +583,7 @@ MAP
             "default_grouptitle" "status"
         END
         CLASS
+            NAME "verblijfsobjecten_verblijfsobject_in_gebruik"
             STYLE
                 SYMBOL "vierkant"
                 COLOR "#7030a0"
@@ -567,6 +602,7 @@ MAP
             "default_grouptitle" "status"
         END
         CLASS
+            NAME "verblijfsobjecten_verblijfsobject_gevormd"
             STYLE
                 SYMBOL "vierkant"
                 ANGLE 45
@@ -586,6 +622,7 @@ MAP
             "default_grouptitle" "status"
         END
         CLASS
+            NAME "verblijfsobjecten_niet_gerealiseerd_verblijfsobject"
             STYLE
                 SYMBOL "stip"
                 COLOR "#ffff00"
@@ -604,6 +641,7 @@ MAP
             "default_grouptitle" "status"
         END
         CLASS
+            NAME "verblijfsobjecten_verblijfsobject_ingetrokken"
             STYLE
                 SYMBOL "stip"
                 COLOR "#00b0f0"
@@ -622,6 +660,7 @@ MAP
             "default_grouptitle" "status"
         END
         CLASS
+            NAME "verblijfsobjecten_verblijfsobject_in_gebruik_niet_ingemeten"
             STYLE
                 SYMBOL "stip"
                 COLOR "#0070c0"
@@ -640,6 +679,7 @@ MAP
             "default_grouptitle" "status"
         END
         CLASS
+            NAME "verblijfsobjecten_verblijfsobject_buiten_gebruik"
             STYLE
                 SYMBOL "rechthoek"
                 COLOR "#ff33cc"
@@ -658,6 +698,7 @@ MAP
             "default_grouptitle" "status"
         END
         CLASS
+            NAME "verblijfsobjecten_verbouwing_verblijfsobject"
             STYLE
                 SYMBOL "pentagon"
                 COLOR "#f79646"


### PR DESCRIPTION
GetLegendGraphic without rule parameter responds with an empty white image when a CLASS NAME is not defined. Contrary to what the docs says: https://mapserver.org/ogc/wms_server.html#parameters. We should be able to get the legend by omitting the rule parameter regardless of CLASS NAME. 

When name the classes the request does work so that is the solution for now.  