### PR TITLE
Revert to url replace vars in topografie_wm.map

### DIFF
--- a/topografie_wm.map
+++ b/topografie_wm.map
@@ -37,7 +37,7 @@ MAP
             "wms_extent"                            "94000 465000 170000 514000"
             "wms_style_default_legendurl_height"    "10"
             "wms_style_default_legendurl_width"     "20"
-            "wms_style_default_legendurl_href"      "http://map/legend/legendabasiskaart.png"
+            "wms_style_default_legendurl_href"      "LEGEND_URL_REPLACE/legend/legendabasiskaart.png"
             "wms_style_default_legendurl_format"    "image/png"
         END
         TYPE POINT
@@ -60,7 +60,7 @@ MAP
             "wms_extent"                            "94000 465000 170000 514000"
             "wms_style_default_legendurl_height"    "10"
             "wms_style_default_legendurl_width"     "20"
-            "wms_style_default_legendurl_href"      "http://map/legend/legendabasiskaartlight.png"
+            "wms_style_default_legendurl_href"      "LEGEND_URL_REPLACE/legend/legendabasiskaartlight.png"
             "wms_style_default_legendurl_format"    "image/png"
         END
         TYPE POINT
@@ -83,7 +83,7 @@ MAP
             "wms_extent"                            "94000 465000 170000 514000"
             "wms_style_default_legendurl_height"    "10"
             "wms_style_default_legendurl_width"     "20"
-            "wms_style_default_legendurl_href"      "http://map/legend/legendabasiskaartzwartwit.png"
+            "wms_style_default_legendurl_href"      "LEGEND_URL_REPLACE/legend/legendabasiskaartzwartwit.png"
             "wms_style_default_legendurl_format"    "image/png"
         END
         TYPE POINT
@@ -101,7 +101,7 @@ MAP
             "init=epsg:3857"
         END
         TYPE                    RASTER
-        CONNECTION              "http://map/maps/kbk50?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
+        CONNECTION              "MAP_URL_REPLACE/maps/kbk50?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           400000
         MINSCALEDENOM           20000
@@ -128,7 +128,7 @@ MAP
             "init=epsg:3857"
         END
         TYPE                    RASTER
-        CONNECTION              "http://map/maps/kbk50?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
+        CONNECTION              "MAP_URL_REPLACE/maps/kbk50?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           400000
         MINSCALEDENOM           20000
@@ -139,7 +139,7 @@ MAP
             "wms_abstract"        "Basiskaart Amsterdam - Light"
             "wms_srs"             "EPSG:3857 EPSG:28992"
             "wms_name"            "vlakken,lijnen"
-            "wms_sld_url"         "http://map/sld/kbk50_light.xml"
+            "wms_sld_url"         "MAP_URL_REPLACE/sld/kbk50_light.xml"
             "wms_format"          "image/png"
             "wms_server_version"  "1.1.1"
             "wms_transparent"     "false"
@@ -156,7 +156,7 @@ MAP
             "init=epsg:3857"
         END
         TYPE                    RASTER
-        CONNECTION              "http://map/maps/kbk50?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
+        CONNECTION              "MAP_URL_REPLACE/maps/kbk50?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           400000
         MINSCALEDENOM           20000
@@ -167,7 +167,7 @@ MAP
             "wms_abstract"        "Basiskaart Amsterdam - ZW"
             "wms_srs"             "EPSG:3857 EPSG:28992"
             "wms_name"            "vlakken,lijnen"
-            "wms_sld_url"         "http://map/sld/kbk50_zw.xml"
+            "wms_sld_url"         "MAP_URL_REPLACE/sld/kbk50_zw.xml"
             "wms_format"          "image/png"
             "wms_server_version"  "1.1.1"
             "wms_transparent"     "false"
@@ -188,7 +188,7 @@ MAP
             "init=epsg:3857"
         END
         TYPE                    RASTER
-        CONNECTION              "http://map/maps/kbk10?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
+        CONNECTION              "MAP_URL_REPLACE/maps/kbk10?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           20000
         MINSCALEDENOM           3500
@@ -215,7 +215,7 @@ MAP
             "init=epsg:3857"
         END
         TYPE                    RASTER
-        CONNECTION              "http://map/maps/kbk10?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
+        CONNECTION              "MAP_URL_REPLACE/maps/kbk10?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           20000
         MINSCALEDENOM           3500
@@ -226,7 +226,7 @@ MAP
             "wms_abstract"        "Basiskaart Amsterdam -Light"
             "wms_srs"             "EPSG:3857 EPSG:28992"
             "wms_name"            "vlakken,lijnen"
-            "wms_sld_url"         "http://map/sld/kbk10_light.xml"
+            "wms_sld_url"         "MAP_URL_REPLACE/sld/kbk10_light.xml"
             "wms_format"          "image/png"
             "wms_server_version"  "1.1.1"
             "wms_transparent"     "false"
@@ -243,7 +243,7 @@ MAP
             "init=epsg:3857"
         END
         TYPE                    RASTER
-        CONNECTION              "http://map/maps/kbk10?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
+        CONNECTION              "MAP_URL_REPLACE/maps/kbk10?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           20000
         MINSCALEDENOM           3500
@@ -254,7 +254,7 @@ MAP
             "wms_abstract"        "Basiskaart Amsterdam - ZW"
             "wms_srs"             "EPSG:3857 EPSG:28992"
             "wms_name"            "vlakken,lijnen"
-            "wms_sld_url"         "http://map/sld/kbk10_zw.xml"
+            "wms_sld_url"         "MAP_URL_REPLACE/sld/kbk10_zw.xml"
             "wms_format"          "image/png"
             "wms_server_version"  "1.1.1"
             "wms_transparent"     "false"
@@ -275,7 +275,7 @@ MAP
             "init=epsg:3857"
         END
         TYPE                    RASTER
-        CONNECTION              "http://map/maps/bgt?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
+        CONNECTION              "MAP_URL_REPLACE/maps/bgt?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           3500
         MINSCALEDENOM           0
@@ -302,7 +302,7 @@ MAP
             "init=epsg:3857"
         END
         TYPE                    RASTER
-        CONNECTION              "http://map/maps/bgt?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
+        CONNECTION              "MAP_URL_REPLACE/maps/bgt?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           3500
         MINSCALEDENOM           0
@@ -313,7 +313,7 @@ MAP
             "wms_abstract"        "Basiskaart Amsterdam - Light"
             "wms_srs"             "EPSG:3857 EPSG:28992"
             "wms_name"            "hoogte0,hoogte1,hoogte2,hoogte3,hoogte4,hoogte_3,hoogte_2,hoogte_1"
-            "wms_sld_url"         "http://map/sld/bgt_light.xml"
+            "wms_sld_url"         "MAP_URL_REPLACE/sld/bgt_light.xml"
             "wms_format"          "image/png"
             "wms_server_version"  "1.1.1"
             "wms_transparent"     "false"
@@ -330,7 +330,7 @@ MAP
           "init=epsg:3857"
         END
         TYPE                      RASTER
-        CONNECTION                "http://map/maps/bgt?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
+        CONNECTION                "MAP_URL_REPLACE/maps/bgt?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE            WMS
         MAXSCALEDENOM             3500
         MINSCALEDENOM             0
@@ -341,7 +341,7 @@ MAP
             "wms_abstract"        "Basiskaart Amsterdam - ZW"
             "wms_srs"             "EPSG:3857 EPSG:28992"
             "wms_name"            "hoogte0,hoogte1,hoogte2,hoogte3,hoogte4,hoogte_3,hoogte_2,hoogte_1"
-            "wms_sld_url"         "http://map/sld/bgt_zw.xml"
+            "wms_sld_url"         "MAP_URL_REPLACE/sld/bgt_zw.xml"
             "wms_format"          "image/png"
             "wms_server_version"  "1.1.1"
             "wms_transparent"     "false"
@@ -362,7 +362,7 @@ MAP
            "init=epsg:3857"
            END
         TYPE                    RASTER
-        CONNECTION              "http://map/maps/kaartteksten?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
+        CONNECTION              "MAP_URL_REPLACE/maps/kaartteksten?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           400000
         MINSCALEDENOM           0
@@ -389,7 +389,7 @@ MAP
           "init=epsg:3857"
         END
         TYPE                    RASTER
-        CONNECTION              "http://map/maps/kaartteksten?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
+        CONNECTION              "MAP_URL_REPLACE/maps/kaartteksten?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           400000
         MINSCALEDENOM           0
@@ -416,7 +416,7 @@ MAP
            "init=epsg:3857"
            END
         TYPE                    RASTER
-        CONNECTION              "http://map/maps/kaartteksten?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
+        CONNECTION              "MAP_URL_REPLACE/maps/kaartteksten?MAP_RESOLUTION=%MAP_RESOLUTION%&DPI=%DPI%"
         CONNECTIONTYPE          WMS
         MAXSCALEDENOM           400000
         MINSCALEDENOM           0


### PR DESCRIPTION
In the containers on acc these are replaced with urls, so they can be resolved. `map` only works on local docker