### PR TITLE
Fix index.json

### DIFF
--- a/tools/make_indexjson.py
+++ b/tools/make_indexjson.py
@@ -30,7 +30,7 @@ def parse_mapfile(filename: str) -> Tuple[str, Dict[str, object]]:
     r = {}
     with open(filename, encoding="utf-8") as f:
         for ln in f:
-            ln = ln.split()
+            ln = ln.split(None, 1)
             if len(ln) == 0:
                 continue
 
@@ -39,6 +39,11 @@ def parse_mapfile(filename: str) -> Tuple[str, Dict[str, object]]:
                 continue
 
             value = ln[1]
+            # Remove comments.
+            if "#" in value:
+                value = value[value.index("#"):]
+            value = value.strip()
+
             if value.startswith('"') or value.startswith("'"):
                 value = value[1:-1]
             r.setdefault(key, value)


### PR DESCRIPTION
Diff:

    --- old	2023-08-16 11:16:17.096685680 +0200
    +++ new	2023-08-16 11:20:59.704663291 +0200
    @@ -1,10 +1,10 @@
     {
       "BRK": {
    -    "abstract": "BR",
    +    "abstract": "BRK objecten met een geografische component",
         "title": "BRK"
       },
       "BRK2": {
    -    "abstract": "BRK-objecte",
    +    "abstract": "BRK-objecten met een geografische component (BRK 2.0)",
         "title": "BRK2"
       },
       "COVID19": {
    @@ -12,131 +12,131 @@
         "title": "COVID19"
       },
       "EIGENDOMMEN": {
    -    "abstract": "Kadastral",
    +    "abstract": "Kadastrale eigendommen, gecategoriseerd",
         "title": "EIGENDOMMEN"
       },
       "ENERGIE": {
    -    "abstract": "Ga",
    +    "abstract": "Gas / elektra - verbruiks gegevens. BAG gecombineerd met Alliander open data",
         "title": "energie"
       },
       "ERFPACHT": {
    -    "abstract": "Kadastral",
    +    "abstract": "Kadastrale erfpacht, uitgegeven door Amsterdam of Overig",
         "title": "ERFPACHT"
       },
       "GEBIEDEN": {
    -    "abstract": "Gebiede",
    +    "abstract": "Gebieden met een geografische component, waarvan Amsterdam de bronhouder is",
         "title": "GEBIEDEN"
       },
       "INFRAROOD": {
    -    "abstract": "Infraroo",
    +    "abstract": "Infrarood foto's van het grondgebied van de gemeente Amsterdam",
         "title": "infrarood"
       },
       "INFRAROOD2018": {
    -    "abstract": "Infraroo",
    -    "title": "INFRAROO"
    +    "abstract": "Infrarood foto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "INFRAROOD 2018"
       },
       "INFRAROOD2020": {
    -    "abstract": "Infraroo",
    -    "title": "INFRAROO"
    +    "abstract": "Infrarood foto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "INFRAROOD 2020"
       },
       "INFRAROOD2021": {
    -    "abstract": "Infraroo",
    -    "title": "INFRAROO"
    +    "abstract": "Infrarood foto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "INFRAROOD 2021"
       },
       "INFRAROOD2022": {
    -    "abstract": "Infraroo",
    -    "title": "INFRAROO"
    +    "abstract": "Infrarood foto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "INFRAROOD 2022"
       },
       "LUFO": {
    -    "abstract": "Luchtfoto'",
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
         "title": "LUFO"
       },
       "LUFO2003": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2003"
       },
       "LUFO2004": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2004"
       },
       "LUFO2005": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2005"
       },
       "LUFO2006": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2006"
       },
       "LUFO2007": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2007"
       },
       "LUFO2008": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2008"
       },
       "LUFO2009": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2009"
       },
       "LUFO2010": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2010"
       },
       "LUFO2011": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2011"
       },
       "LUFO2012": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2012"
       },
       "LUFO2013": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2013"
       },
       "LUFO2014": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2014"
       },
       "LUFO2015": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2015"
       },
       "LUFO2016": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2016"
       },
       "LUFO2017": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2017"
       },
       "LUFO2018": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2018"
       },
       "LUFO2019": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2019"
       },
       "LUFO2020": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2020"
       },
       "LUFO2021": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2021"
       },
       "LUFO2022": {
    -    "abstract": "Luchtfoto'",
    -    "title": "LUFO'"
    +    "abstract": "Luchtfoto's van het grondgebied van de gemeente Amsterdam",
    +    "title": "LUFO'S 2022"
       },
       "Meetbouten": {
    -    "abstract": "Meetboutgegeven",
    +    "abstract": "Meetboutgegevens van het grondgebied van de gemeente Amsterdam",
         "title": "Meetbouten"
       },
       "NAP": {
    -    "abstract": "NA",
    +    "abstract": "NAP gegevens van het grondgebied van de gemeente Amsterdam",
         "title": "NAP"
       },
       "Overlastgebieden": {
    @@ -144,162 +144,158 @@
         "title": "Overlastgebieden"
       },
       "PARKEERVAKKEN": {
    -    "abstract": "Parkeervakke",
    +    "abstract": "Parkeervakken met een geografische component, waarvan Amsterdam de bronhouder is",
         "title": "PARKEERVAKKEN"
       },
       "PRECARIOBELASTINGgebiedEN": {
    -    "abstract": "Precariobelastinggebiede",
    +    "abstract": "Precariobelastinggebieden waarvan Amsterdam de bronhouder is",
         "title": "Precariobelastinggebieden"
       },
       "Panoramas": {
    -    "abstract": "Panoram",
    +    "abstract": "Panorama opnamelocaties en trajecten",
         "title": "Panoramas"
       },
       "aardgasvrij": {
    -    "abstract": "Aardgasvri",
    +    "abstract": "Aardgasvrij status per buurt",
         "title": "Aardgasvrij"
       },
       "adresseerbare_objecten": {
         "abstract": "adresseerbare_objecten",
         "title": "adresseerbare_objecten"
       },
    -  "bagmap": {
    -    "abstract": "BA",
    -    "title": "BAG"
    -  },
       "bb_quotum": {
    -    "abstract": "Vergunninge",
    -    "title": "Vergunninge"
    +    "abstract": "Vergunningen B&B per wijk",
    +    "title": "Vergunningen B&B"
       },
       "beheerkaart": {
    -    "abstract": "Zakelij",
    +    "abstract": "Zakelijk recht publieke ruimte Amsterdam",
         "title": "beheerkaart"
       },
       "beschermdestadsdorpsgezichten": {},
       "bgt": {
    -    "abstract": "Basisregistrati",
    +    "abstract": "Basisregistratie Grootschalige Topografie",
         "title": "bgt"
       },
       "bgt_inrichtingselementen": {
    -    "abstract": "Basisregistrati",
    +    "abstract": "Basisregistratie Grootschalige Topografie PLUS",
         "title": "bgt_inrichtingselementen"
       },
       "bgtobjecten": {
    -    "abstract": "Basisregistrati",
    +    "abstract": "Basisregistratie Grootschalige Topografie, objecten",
         "title": "bgtobjecten"
       },
       "biz": {
    -    "abstract": "Bedrijfsinvesteringszon",
    +    "abstract": "Bedrijfsinvesteringszone Amsterdam",
         "title": "Bedrijfsinvesteringszone"
       },
       "bodeminformatie": {
    -    "abstract": "Bodeminformati",
    +    "abstract": "Bodeminformatie van het grondgebied van de gemeente Amsterdam",
         "title": "Bodeminformatie"
       },
       "bomen": {},
       "bommenkaart": {
    -    "abstract": "Bommenkaar",
    +    "abstract": "Bommenkaart Amsterdam",
         "title": "bommenkaart"
       },
       "containers": {
    -    "abstract": "Afvalcontainer",
    +    "abstract": "Afvalcontainers Amsterdam",
         "title": "afvalcontainers"
       },
       "externeveiligheid": {
    -    "abstract": "Extern",
    -    "title": "Extern"
    +    "abstract": "Externe veiligheid",
    +    "title": "Externe veiligheid"
       },
       "fietspaaltjes": {
         "abstract": "fietspaaltjes",
         "title": "fietspaaltjes"
       },
       "grex": {
    -    "abstract": "Grondexploitati",
    +    "abstract": "Grondexploitatie Amsterdam",
         "title": "grondexploitatie"
       },
       "hoofdroutes": {
    -    "abstract": "Hoofdroute",
    +    "abstract": "Hoofdroutes Amsterdam",
         "title": "Hoofdroutes"
       },
       "huishoudelijkafval": {
    -    "abstract": "Huishoudelij",
    +    "abstract": "Huishoudelijk afval",
         "title": "huishoudelijkafval"
       },
       "kaartteksten": {},
       "kbk10": {
    -    "abstract": "Kleinschalig",
    +    "abstract": "Kleinschalige Basiskaart 10k",
         "title": "kbk10"
       },
       "kbk50": {
    -    "abstract": "Kleinschalig",
    +    "abstract": "Kleinschalige Basiskaart 50k",
         "title": "kbk50"
       },
       "loodkaart": {
    -    "abstract": "BA",
    +    "abstract": "BAG panden met kleurcodering voor panden ouder dan 1960",
         "title": "Loodkaart"
       },
       "milieuzones": {
    -    "abstract": "Milieuzone",
    +    "abstract": "Milieuzones Amsterdam",
         "title": "Milieuzones"
       },
       "monumenten": {
    -    "abstract": "Monumente",
    +    "abstract": "Monumenten Amsterdam",
         "title": "monumenten"
       },
       "omzettingen_quotum": {
    -    "abstract": "Vergunninge",
    -    "title": "Vergunninge"
    +    "abstract": "Vergunningen omzettingen per wijk",
    +    "title": "Vergunningen omzettingen"
       },
       "ondergrond": {
         "abstract": "ondergrond",
         "title": "ondergrond"
       },
       "openbare_verlichting": {
    -    "abstract": "Openbare_verlichtin",
    +    "abstract": "Openbare_verlichting Amsterdam",
         "title": "Openbare_verlichting"
       },
       "oplaadpunten": {
    -    "abstract": "Oplaadpunte",
    +    "abstract": "Oplaadpunten Amsterdam",
         "title": "Oplaadpunten"
       },
       "parkeerzones": {
    -    "abstract": "Parkeerzone",
    +    "abstract": "Parkeerzones Amsterdam",
         "title": "Parkeerzones"
       },
       "parkeerzones_uitz": {
    -    "abstract": "Parkeerzone",
    -    "title": "Parkeerzone"
    +    "abstract": "Parkeerzones uitzonderingen Amsterdam",
    +    "title": "Parkeerzones uitzonderingen"
       },
       "planologischegeluidszones": {
    -    "abstract": "Planologisch",
    -    "title": "Planologisch"
    +    "abstract": "Planologische geluidszones",
    +    "title": "Planologische geluidszones"
       },
       "planologischezonesschiphol": {
    -    "abstract": "Planologisch",
    -    "title": "Planologisch"
    +    "abstract": "Planologische zones Schiphol",
    +    "title": "Planologische zones Schiphol"
       },
       "reclamebelasting": {
    -    "abstract": "Reclam",
    -    "title": "Reclam"
    +    "abstract": "Reclame belastingtarieven",
    +    "title": "Reclame belastingtarieven"
       },
       "sport": {
         "abstract": "sport",
         "title": "sport"
       },
       "stroomstoringen": {
    -    "abstract": "Stroomstoringe",
    -    "title": "Stroomstoringe"
    +    "abstract": "Stroomstoringen (van vandaag) netwerk van Liander regio Amsterdam.",
    +    "title": "Stroomstoringen Liander regio Amsterdam"
       },
       "topografie": {
    -    "abstract": "Basiskaar",
    +    "abstract": "Basiskaart Amsterdam",
         "title": "topografie"
       },
       "touringcars": {
    -    "abstract": "Touringcar",
    -    "title": "Touringcar"
    +    "abstract": "Touringcars categorieën waarvan Amsterdam de bronhouder is",
    +    "title": "Touringcars categorieën"
       },
       "trm": {
    -    "abstract": "Tra",
    +    "abstract": "Tram en Metro lijnen Amsterdam",
         "title": "Tram_Metro"
       },
       "varen": {
    @@ -307,19 +303,19 @@
         "title": "varen"
       },
       "vastgoed": {
    -    "abstract": "Vastgoe",
    +    "abstract": "Vastgoed van de gemeente Amsterdam",
         "title": "vastgoed"
       },
       "vezips": {
    -    "abstract": "Verzinkbar",
    +    "abstract": "Verzinkbare palen",
         "title": "vezips"
       },
       "vuurwerk": {
    -    "abstract": "Vuurwerkvrij",
    +    "abstract": "Vuurwerkvrije zones",
         "title": "vuurwerk"
       },
       "wegenbestand": {
    -    "abstract": "Wegenbestan",
    +    "abstract": "Wegenbestand gemeente Amsterdam",
         "title": "wegenbestand"
       },
       "winkgeb": {