### PR TITLE
Fix SQL bug in monumenten

### DIFF
--- a/monumenten.map
+++ b/monumenten.map
@@ -38,7 +38,7 @@ MAP
         geometrie FROM (
             SELECT coalesce(ST_CollectionExtract(monumentgeometrie, 3),
                             ST_Buffer(monumentcoordinaten, 1.5)) AS geometrie,
-                   id FROM public.dataset_monument
+                   * FROM public.dataset_monument
             ) AS query
         USING srid=28992 USING UNIQUE id"
     TYPE                    POLYGON


### PR DESCRIPTION
It selected too few fields to even execute its FILTER for "nopand". Select everything so we can satisfy `gml_include_items`, which restricts the fields served.

Fixes AB#93379.