### PR TITLE
Fix caterpillar queries

### DIFF
--- a/gen_ziektenplagenexotengroen.py
+++ b/gen_ziektenplagenexotengroen.py
@@ -45,9 +45,8 @@ with block("MAP"):
                 "geometrie FROM"
                 # This subquery appears to do nothing, but it actually restricts
                 # the fields that mapserver sees.
-                " (SELECT id, geometrie, ranking FROM public.ziekte_plagen_exoten_groen_eikenprocessierups) AS sub"
+                " (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub"
                 " USING srid=28992 USING UNIQUE id"
-                " WHERE ranking=1",
             )
             p("TYPE POINT")
 

--- a/ziektenplagenexotengroen.map
+++ b/ziektenplagenexotengroen.map
@@ -19,7 +19,7 @@ MAP
       'init=epsg:28992'
     END
     INCLUDE 'connection/dataservices.inc'
-    DATA 'geometrie FROM (SELECT id, geometrie, ranking FROM public.ziekte_plagen_exoten_groen_eikenprocessierups) AS sub USING srid=28992 USING UNIQUE id WHERE ranking=1'
+    DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
       'wfs_enable_request' 'none'
@@ -49,7 +49,7 @@ MAP
       'init=epsg:28992'
     END
     INCLUDE 'connection/dataservices.inc'
-    DATA 'geometrie FROM (SELECT id, geometrie, ranking FROM public.ziekte_plagen_exoten_groen_eikenprocessierups) AS sub USING srid=28992 USING UNIQUE id WHERE ranking=1'
+    DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
       'wfs_enable_request' 'none'
@@ -79,7 +79,7 @@ MAP
       'init=epsg:28992'
     END
     INCLUDE 'connection/dataservices.inc'
-    DATA 'geometrie FROM (SELECT id, geometrie, ranking FROM public.ziekte_plagen_exoten_groen_eikenprocessierups) AS sub USING srid=28992 USING UNIQUE id WHERE ranking=1'
+    DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
       'wfs_enable_request' 'none'
@@ -109,7 +109,7 @@ MAP
       'init=epsg:28992'
     END
     INCLUDE 'connection/dataservices.inc'
-    DATA 'geometrie FROM (SELECT id, geometrie, ranking FROM public.ziekte_plagen_exoten_groen_eikenprocessierups) AS sub USING srid=28992 USING UNIQUE id WHERE ranking=1'
+    DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
       'wfs_enable_request' 'none'
@@ -139,7 +139,7 @@ MAP
       'init=epsg:28992'
     END
     INCLUDE 'connection/dataservices.inc'
-    DATA 'geometrie FROM (SELECT id, geometrie, ranking FROM public.ziekte_plagen_exoten_groen_eikenprocessierups) AS sub USING srid=28992 USING UNIQUE id WHERE ranking=1'
+    DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
       'wfs_enable_request' 'none'
@@ -169,7 +169,7 @@ MAP
       'init=epsg:28992'
     END
     INCLUDE 'connection/dataservices.inc'
-    DATA 'geometrie FROM (SELECT id, geometrie, ranking FROM public.ziekte_plagen_exoten_groen_eikenprocessierups) AS sub USING srid=28992 USING UNIQUE id WHERE ranking=1'
+    DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
       'wfs_enable_request' 'none'
@@ -199,7 +199,7 @@ MAP
       'init=epsg:28992'
     END
     INCLUDE 'connection/dataservices.inc'
-    DATA 'geometrie FROM (SELECT id, geometrie, ranking FROM public.ziekte_plagen_exoten_groen_eikenprocessierups) AS sub USING srid=28992 USING UNIQUE id WHERE ranking=1'
+    DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
       'wfs_enable_request' 'none'
@@ -229,7 +229,7 @@ MAP
       'init=epsg:28992'
     END
     INCLUDE 'connection/dataservices.inc'
-    DATA 'geometrie FROM (SELECT id, geometrie, ranking FROM public.ziekte_plagen_exoten_groen_eikenprocessierups) AS sub USING srid=28992 USING UNIQUE id WHERE ranking=1'
+    DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
       'wfs_enable_request' 'none'
@@ -259,7 +259,7 @@ MAP
       'init=epsg:28992'
     END
     INCLUDE 'connection/dataservices.inc'
-    DATA 'geometrie FROM (SELECT id, geometrie, ranking FROM public.ziekte_plagen_exoten_groen_eikenprocessierups) AS sub USING srid=28992 USING UNIQUE id WHERE ranking=1'
+    DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
       'wfs_enable_request' 'none'


### PR DESCRIPTION
These were broken, but for some reason mapserver gives HTTP status 200 with an error message in the body, so I didn't notice when checking only the QGIS debug toolbar.