### PR TITLE
Properly disable WFS for BRK2 and some other maps

### DIFF
--- a/beschermdestadsdorpsgezichten.map
+++ b/beschermdestadsdorpsgezichten.map
@@ -22,7 +22,7 @@ MAP
     DATA 'geometry FROM public.beschermdestadsdorpsgezichten_beschermdestadsdorpsgezichten USING UNIQUE id USING srid=28992'
     TYPE POLYGON
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Gemeentelijk beschermd stadsgezicht'
       'wms_enable_request' '*'
       'wms_abstract' 'Beschermde stads- en dorpsgezichten'
@@ -51,7 +51,7 @@ MAP
     DATA 'geometry FROM public.beschermdestadsdorpsgezichten_beschermdestadsdorpsgezichten USING UNIQUE id USING srid=28992'
     TYPE POLYGON
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Gemeentelijk beschermd dorpsgezicht'
       'wms_enable_request' '*'
       'wms_abstract' 'Beschermde stads- en dorpsgezichten'
@@ -80,7 +80,7 @@ MAP
     DATA 'geometry FROM public.beschermdestadsdorpsgezichten_beschermdestadsdorpsgezichten USING UNIQUE id USING srid=28992'
     TYPE POLYGON
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Rijksbeschermd stadsgezicht'
       'wms_enable_request' '*'
       'wms_abstract' 'Beschermde stads- en dorpsgezichten'
@@ -109,7 +109,7 @@ MAP
     DATA 'geometry FROM public.beschermdestadsdorpsgezichten_beschermdestadsdorpsgezichten USING UNIQUE id USING srid=28992'
     TYPE POLYGON
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Rijksbeschermd dorpsgezicht'
       'wms_enable_request' '*'
       'wms_abstract' 'Beschermde stads- en dorpsgezichten'

--- a/bomen.map
+++ b/bomen.map
@@ -24,7 +24,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Iep (Ulmus)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Iep (Ulmus)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -53,7 +53,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Linde (Tilia)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Linde (Tilia)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -82,7 +82,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Esdoorn (Acer)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Esdoorn (Acer)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -111,7 +111,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Es (Fraxinus)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Es (Fraxinus)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -140,7 +140,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Plataan (Platanus)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Plataan (Platanus)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -169,7 +169,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Eik (Quercus)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Eik (Quercus)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -198,7 +198,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Populier (Populus)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Populier (Populus)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -227,7 +227,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Els (Alnus)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Els (Alnus)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -256,7 +256,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Wilg (Salix)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Wilg (Salix)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -285,7 +285,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Berk (Betula)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Berk (Betula)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -314,7 +314,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Kers (Prunus)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Kers (Prunus)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -343,7 +343,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Haagbeuk (Carpinus)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Haagbeuk (Carpinus)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -372,7 +372,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Meidoorn (Crataegus)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Meidoorn (Crataegus)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -401,7 +401,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Acacia (Robinia)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Acacia (Robinia)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -430,7 +430,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Paardenkastanje (Aesculus)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Paardenkastanje (Aesculus)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -459,7 +459,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Vleugelnoot (Pterocarya)')) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Vleugelnoot (Pterocarya)'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -488,7 +488,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top = 'Onbekend' OR soortnaam_top IS NULL)) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Onbekende soorten'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'
@@ -517,7 +517,7 @@ MAP
     DATA "geometrie FROM (   SELECT id, geometrie, soortnaam_top FROM public.bomen_stamgegevens   WHERE type_soortnaam = 'Bomen'  AND (soortnaam_top != 'Iep (Ulmus)' AND soortnaam_top != 'Linde (Tilia)' AND soortnaam_top != 'Esdoorn (Acer)' AND soortnaam_top != 'Es (Fraxinus)' AND soortnaam_top != 'Plataan (Platanus)' AND soortnaam_top != 'Eik (Quercus)' AND soortnaam_top != 'Populier (Populus)' AND soortnaam_top != 'Els (Alnus)' AND soortnaam_top != 'Wilg (Salix)' AND soortnaam_top != 'Berk (Betula)' AND soortnaam_top != 'Kers (Prunus)' AND soortnaam_top != 'Haagbeuk (Carpinus)' AND soortnaam_top != 'Meidoorn (Crataegus)' AND soortnaam_top != 'Acacia (Robinia)' AND soortnaam_top != 'Paardenkastanje (Aesculus)' AND soortnaam_top != 'Vleugelnoot (Pterocarya)' AND soortnaam_top IS NOT NULL)) AS sub USING srid=28992 USING UNIQUE id"
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Overige soorten'
       'wms_enable_request' '*'
       'wms_srs' 'EPSG:28992'

--- a/brk2.map
+++ b/brk2.map
@@ -32,12 +32,10 @@ MAP
     END
 
     METADATA
-      "wfs_enable_request"  "none"
+      "wfs_enable_request"  "!*"
       "ows_title"           "kadastraal_object"
       "ows_group_title"     "kadaster"
       "ows_abstract"        "Kadastrale objecten"
-      "gml_featureid"       "ID"
-      "gml_include_items"   "all"
     END
 
     CLASS
@@ -67,12 +65,10 @@ MAP
     END
 
     METADATA
-      "wfs_enable_request"  "none"
+      "wfs_enable_request"  "!*"
       "ows_title"           "kadastrale_sectie"
       "ows_group_title"     "kadaster"
       "ows_abstract"        "Kadastrale secties"
-      "gml_featureid"       "ID"
-      "gml_include_items"   "all"
     END
 
     CLASS
@@ -102,12 +98,10 @@ MAP
     END
 
     METADATA
-      "wfs_enable_request"  "none"
+      "wfs_enable_request"  "!*"
       "ows_title"           "kadastrale_gemeente"
       "ows_group_title"     "kadaster"
       "ows_abstract"        "Kadastrale gemeentegrenzen"
-      "gml_featureid"       "ID"
-      "gml_include_items"   "all"
     END
 
     CLASS
@@ -140,12 +134,10 @@ MAP
     END
 
     METADATA
-      "wfs_enable_request"  "none"
+      "wfs_enable_request"  "!*"
       "ows_title"           "burgerlijke_gemeente"
       "ows_group_title"     "kadaster"
       "ows_abstract"        "Burgerlijke gemeentegrenzen"
-      "gml_featureid"       "ID"
-      "gml_include_items"   "all"
     END
 
     CLASS
@@ -180,7 +172,7 @@ MAP
     END
 
     METADATA
-      "wfs_enable_request"  "none"
+      "wfs_enable_request"  "!*"
       "ows_title"           "kadastraal_object_label"
       "ows_group_title"     "kadaster"
       "ows_abstract"        "Labels van kadastrale objecten"
@@ -223,7 +215,7 @@ MAP
     END
 
     METADATA
-      "wfs_enable_request"  "none"
+      "wfs_enable_request"  "!*"
       "ows_title"           "kadastrale_sectie_label"
       "ows_group_title"     "kadaster"
       "ows_abstract"        "Labels van kadastrale secties"
@@ -266,7 +258,7 @@ MAP
     END
 
     METADATA
-      "wfs_enable_request"  "none"
+      "wfs_enable_request"  "!*"
       "ows_title"           "kadastrale_gemeente_label"
       "ows_group_title"     "kadaster"
       "ows_abstract"        "Labels van kadastrale gemeentegrenzen"
@@ -312,7 +304,7 @@ MAP
     END
 
     METADATA
-      "wfs_enable_request"  "none"
+      "wfs_enable_request"  "!*"
       "ows_title"           "burgerlijke_gemeente_label"
       "ows_group_title"     "kadaster"
       "ows_abstract"        "Label van burgerlijke gemeentegrenzen"

--- a/gen_beschermdestadsdorpsgezichten.py
+++ b/gen_beschermdestadsdorpsgezichten.py
@@ -45,7 +45,7 @@ with block("MAP"):
             p("TYPE POLYGON")
 
             with block("METADATA"):
-                q("wfs_enable_request", "none")
+                q("wfs_enable_request", "!*")
                 q("wms_title", name)
                 q("wms_enable_request", "*")
                 q("wms_abstract", BSD_LONG)

--- a/gen_bomen.py
+++ b/gen_bomen.py
@@ -73,7 +73,7 @@ with block("MAP"):
             p("TYPE POINT")
 
             with block("METADATA"):
-                q("wfs_enable_request", "none")
+                q("wfs_enable_request", "!*")
                 q("wms_title", name)
                 q("wms_enable_request", "*")
                 q("wms_srs", "EPSG:28992")

--- a/gen_ziektenplagenexotengroen.py
+++ b/gen_ziektenplagenexotengroen.py
@@ -51,7 +51,7 @@ with block("MAP"):
             p("TYPE POINT")
 
             with block("METADATA"):
-                q("wfs_enable_request", "none")
+                q("wfs_enable_request", "!*")
                 q("wms_title", name)
                 q("wms_enable_request", "*")
                 q("wms_abstract", "Eikenprocessierups Amsterdam")

--- a/ziektenplagenexotengroen.map
+++ b/ziektenplagenexotengroen.map
@@ -22,7 +22,7 @@ MAP
     DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Eikenprocessierups aanwezig (Laag)'
       'wms_enable_request' '*'
       'wms_abstract' 'Eikenprocessierups Amsterdam'
@@ -52,7 +52,7 @@ MAP
     DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Eikenprocessierups deels bestreden'
       'wms_enable_request' '*'
       'wms_abstract' 'Eikenprocessierups Amsterdam'
@@ -82,7 +82,7 @@ MAP
     DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Niet in beheergebied Gemeente Amsterdam'
       'wms_enable_request' '*'
       'wms_abstract' 'Eikenprocessierups Amsterdam'
@@ -112,7 +112,7 @@ MAP
     DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Eikenprocessierups aanwezig (Urgent)'
       'wms_enable_request' '*'
       'wms_abstract' 'Eikenprocessierups Amsterdam'
@@ -142,7 +142,7 @@ MAP
     DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Gemeld'
       'wms_enable_request' '*'
       'wms_abstract' 'Eikenprocessierups Amsterdam'
@@ -172,7 +172,7 @@ MAP
     DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Eikenprocessierups bestreden'
       'wms_enable_request' '*'
       'wms_abstract' 'Eikenprocessierups Amsterdam'
@@ -202,7 +202,7 @@ MAP
     DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Geen Eikenprocessierups aanwezig'
       'wms_enable_request' '*'
       'wms_abstract' 'Eikenprocessierups Amsterdam'
@@ -232,7 +232,7 @@ MAP
     DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Niet bereikbaar voor bestrijding'
       'wms_enable_request' '*'
       'wms_abstract' 'Eikenprocessierups Amsterdam'
@@ -262,7 +262,7 @@ MAP
     DATA 'geometrie FROM (SELECT id, geometrie, urgentie_status_kaartlaag FROM public.ziekte_plagen_exoten_groen_eikenprocessierups WHERE ranking=1) AS sub USING srid=28992 USING UNIQUE id'
     TYPE POINT
     METADATA
-      'wfs_enable_request' 'none'
+      'wfs_enable_request' '!*'
       'wms_title' 'Eikenprocessierups aanwezig (Standaard)'
       'wms_enable_request' '*'
       'wms_abstract' 'Eikenprocessierups Amsterdam'


### PR DESCRIPTION
I thought I disabled this in 16b122751e77b65e29df7ce0a08419da59d91cc8, following the recipe from #349, but that didn't work. Fix all maps that used the wrong recipe to prevent future copy-paste errors.

See also https://www.mapserver.org/development/rfc/ms-rfc-67.html.