### PR TITLE
Remove the extra conditions for apache

### DIFF
--- a/docker/000-default.conf
+++ b/docker/000-default.conf
@@ -5,20 +5,20 @@
   DocumentRoot /srv/mapserver
 
   # X-forwarded-For must be present in production otherwise we cant determine the access scope
-  <If "-z osenv('LOCAL')">
-    RewriteEngine On
-    RewriteCond %{HTTP:X-Forwarded-For} ^$
-    # allow healthchecks without the header
-    # We check the querystring here because rewrites inside <If/> are evaluated after toplevel rewrites
-    # and we use PassThrough (PT) rewrites
-    RewriteCond expr "! %{QUERY_STRING} -strmatch '*healthcheck.map*'"
-    RewriteRule ^ - [F]
-  </If>
+  # <If "-z osenv('LOCAL')">
+  #   RewriteEngine On
+  #   RewriteCond %{HTTP:X-Forwarded-For} ^$
+  #   # allow healthchecks without the header
+  #   # We check the querystring here because rewrites inside <If/> are evaluated after toplevel rewrites
+  #   # and we use PassThrough (PT) rewrites
+  #   RewriteCond expr "! %{QUERY_STRING} -strmatch '*healthcheck.map*'"
+  #   RewriteRule ^ - [F]
+  # </If>
 
-  # Allow private access for clients on internal networks and dev environments
-  # there is no nice way to set defaults, so thats why we have the ugly mutually exclusive conditions here
-  SetEnvIfExpr "-n osenv('LOCAL') || req('X-Forwarded-For') -ipmatch '10.0.0.0/8' || req('X-Forwarded-For') -ipmatch '172.16.0.0/12' || req('X-forwarded-For') -ipmatch '192.168.0.0/16'" MS_MAP_PATTERN=\/srv\/mapserver\/[^/]+\.map|\/srv\/mapserver\/private\/[^/]+\.map
-  SetEnvIfExpr "! (-n osenv('LOCAL') || req('X-Forwarded-For') -ipmatch '10.0.0.0/8' || req('X-Forwarded-For') -ipmatch '172.16.0.0/12' || req('X-forwarded-For') -ipmatch '192.168.0.0/16')" MS_MAP_PATTERN=\/srv\/mapserver\/[^/]+\.map
+  # # Allow private access for clients on internal networks and dev environments
+  # # there is no nice way to set defaults, so thats why we have the ugly mutually exclusive conditions here
+  # SetEnvIfExpr "-n osenv('LOCAL') || req('X-Forwarded-For') -ipmatch '10.0.0.0/8' || req('X-Forwarded-For') -ipmatch '172.16.0.0/12' || req('X-forwarded-For') -ipmatch '192.168.0.0/16'" MS_MAP_PATTERN=\/srv\/mapserver\/[^/]+\.map|\/srv\/mapserver\/private\/[^/]+\.map
+  # SetEnvIfExpr "! (-n osenv('LOCAL') || req('X-Forwarded-For') -ipmatch '10.0.0.0/8' || req('X-Forwarded-For') -ipmatch '172.16.0.0/12' || req('X-forwarded-For') -ipmatch '192.168.0.0/16')" MS_MAP_PATTERN=\/srv\/mapserver\/[^/]+\.map
 
   # Uncomment the following line for maximum rewrite logging
   LogLevel debug rewrite:trace8


### PR DESCRIPTION
There are some extra conditions in the Apache config for LOCAL development.
Those are depending on a LOCAL variable that has only been set in the docker-compose (so for local dev).

It turns out that these extra configs are blocking for the topgrafie (and lufo) maps.
This PR removes this config.

The config has been left in the code to be evaluated further in a later stage, because maybe it can be replaced with something less lethal that is helpful for local development.