### PR TITLE
Revert "In vastgoed.map, use verhuurbare_eenheid_nummer as id"

### DIFF
--- a/vastgoed.map
+++ b/vastgoed.map
@@ -30,14 +30,9 @@ MAP
       "init=epsg:28992"
     END
 
-    INCLUDE "connection/dataservices.inc"
-
-    # Use verhuurbare_eenheid_nummer as the identifier for compatibility
-    # with Geosearch.
+    INCLUDE                 "connection/dataservices.inc"
     DATA "geometrie FROM (
-            SELECT DISTINCT ON (vv.verhuurbare_eenheid_nummer)
-                bp.geometrie, vv.pand_id, vv.verhuurbare_eenheid_nummer
-            FROM (
+            SELECT DISTINCT ON (vv.pand_id) bp.geometrie, vv.pand_id FROM (
                 vastgoed_vastgoed vv INNER JOIN bag_panden bp
                 ON vv.pand_id = bp.identificatie
             )
@@ -45,7 +40,7 @@ MAP
                 AND (bp.eind_geldigheid IS NULL OR bp.eind_geldigheid  > now())
                 AND object_eigendomsstatus = 'volle eigendom'
             )
-            AS sub USING srid=28992 USING UNIQUE verhuurbare_eenheid_nummer"
+            AS sub USING srid=28992 USING UNIQUE pand_id"
     TYPE                    POLYGON
     MINSCALEDENOM           10
     MAXSCALEDENOM           400000
@@ -95,14 +90,9 @@ MAP
       "init=epsg:28992"
     END
 
-    INCLUDE "connection/dataservices.inc"
-
-    # Use verhuurbare_eenheid_nummer as the identifier for compatibility
-    # with Geosearch.
+    INCLUDE                 "connection/dataservices.inc"
     DATA "geometrie FROM (
-            SELECT DISTINCT ON (vv.verhuurbare_eenheid_nummer)
-                bp.geometrie, vv.pand_id, vv.verhuurbare_eenheid_nummer
-            FROM (
+            SELECT DISTINCT ON (vv.pand_id) bp.geometrie, vv.pand_id FROM (
                 vastgoed_vastgoed vv INNER JOIN bag_panden bp
                 ON vv.pand_id = bp.identificatie
             )
@@ -110,7 +100,7 @@ MAP
                 AND (bp.eind_geldigheid IS NULL OR bp.eind_geldigheid  > now())
                 AND object_eigendomsstatus = 'appartementsrecht'
             )
-            AS sub USING srid=28992 USING UNIQUE verhuurbare_eenheid_nummer"
+            AS sub USING srid=28992 USING UNIQUE pand_id"
     TYPE                    POLYGON
     MINSCALEDENOM           10
     MAXSCALEDENOM           400000


### PR DESCRIPTION
This reverts commit d59bc41505a8ff2a46282d043d475d2255246e67.

Doesn't solve the data.amsterdam.nl issue that we were trying to solve. Instead, Geosearch and DSO-API are inconsistent wrt. how to identify vastgoed objects.