### PR TITLE
Remove cirkel_correctie_punt from symbol list

### DIFF
--- a/symbols/symbollist.txt
+++ b/symbols/symbollist.txt
@@ -333,12 +333,6 @@ SYMBOL
 END
 
 SYMBOL
-  NAME      "cirkel_correctie_punt"
-  TYPE      SVG
-  IMAGE     "iconen/cirkel_correctie_punt.svg"
-END
-
-SYMBOL
   NAME      "cirkel_correctie_legenda"
   TYPE      SVG
   IMAGE     "iconen/cirkel_correctie_legend.svg"


### PR DESCRIPTION
File was removed in #427, but left on the list.