### PR TITLE
Set ows_contactperson to "N/A"

### DIFF
--- a/header.inc
+++ b/header.inc
@@ -58,7 +58,7 @@
 
       # verplicht om aan de OGC standaard te voldoen:
       "ows_contactorganization"      "gemeente Amsterdam"
-      "ows_contactperson"            "Onderzoek, Informatie en Statistiek"
+      "ows_contactperson"            "N/A"
     END
 
     IMAGEPATH                        "/srv/mapserver/tmp_img/"

--- a/private/header.inc
+++ b/private/header.inc
@@ -51,7 +51,7 @@
 
       # verplicht om aan de OGC standaard te voldoen:
       "ows_contactorganization"      "gemeente Amsterdam"
-      "ows_contactperson"            "Basisinformatie"
+      "ows_contactperson"            "N/A"
     END
 
     IMAGEPATH                        "/srv/mapserver/tmp_img/"


### PR DESCRIPTION
This setting was inconsistent between header.inc and private/header.inc and out of date in both cases. It's bound to go out of date again, so no meaningful value entered. Not the empty string as I wasn't sure if that would work.