### PR TITLE
Make local dev environment more like refdb on Azure

### DIFF
--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -1,0 +1,7 @@
+# Dockerfile for PostgreSQL in dev environment only.
+
+# TODO upgrade to a newer Postgres. Trouble is that the hack to move
+# PostGIS doesn't work with newer versions.
+FROM amsterdam/postgres11
+
+ADD docker/initdb.d/* /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,13 @@ version: "3.0"
 
 services:
   database:
-    image: amsterdam/postgres11
+    build:
+      context: .
+      dockerfile: Dockerfile.database
     ports:
       - "5403:5432"
     environment:
       - POSTGRES_PASSWORD=insecure
-    volumes:
-        - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
     command: ["postgres", "-c", "log_statement=all"]
 
   proxy:
@@ -61,7 +61,7 @@ services:
       PANORAMA_DB_HOST: database
 
       BASISKAART_DB_NAME: basiskaart
-      BASISKAART_DB_USER: basiskaart_read
+      BASISKAART_DB_USER: postgres
       BASISKAART_DB_PASSWORD: insecure
       BASISKAART_DB_HOST: database
 
@@ -76,12 +76,12 @@ services:
       DATASELECTIE_DB_HOST: database
 
       VARIOUS_SMALL_DATASETS_DB_NAME: various_small_datasets
-      VARIOUS_SMALL_DATASETS_DB_USER: various_small_datasets
+      VARIOUS_SMALL_DATASETS_DB_USER: postgres
       VARIOUS_SMALL_DATASETS_DB_PASSWORD: insecure
       VARIOUS_SMALL_DATASETS_DB_HOST: database
 
       DATASERVICES_DB_NAME: dataservices
-      DATASERVICES_DB_USER: dataservices
+      DATASERVICES_DB_USER: postgres
       DATASERVICES_DB_PASSWORD: insecure
       DATASERVICES_DB_HOST: database
 

--- a/docker/initdb.d/90_extension_schema.sql
+++ b/docker/initdb.d/90_extension_schema.sql
@@ -1,0 +1,22 @@
+CREATE SCHEMA IF NOT EXISTS extensions;
+
+-- Move postgis to the schema extensions, to match the refdb,
+-- then add it to the search_path so that MapServer can find its functions.
+-- See https://postgis.net/documentation/tips/tip-move-postgis-schema/ for
+-- an explanation of this elaborate dance.
+--
+-- XXX This hack no longer works with PostGIS 3.4; the UPDATE TO statements
+-- fail. Moving to another schema without those results in a broken extension.
+UPDATE pg_extension SET
+    extrelocatable = true
+WHERE
+    extname = 'postgis';
+
+ALTER EXTENSION postgis SET SCHEMA extensions;
+
+ALTER EXTENSION postgis UPDATE TO "2.5.5next";
+
+ALTER EXTENSION postgis UPDATE TO "2.5.5";
+
+-- Change search path for postgres user, permanently.
+ALTER USER postgres SET SEARCH_PATH TO public, extensions, "$user";


### PR DESCRIPTION
Since the Azure migration, the refdb has had PostGIS in the "extensions" schema rather than the "public" schema. This confuses DBeaver when copying tables from refdb to local dev env, since the geometry type is called "geometry" on one end and "extensions.geometry" on the other.

The fix is a collection of ugly hacks, since I couldn't get the proper solution of upgrading to PostgreSQL 14 + PostGIS 3.4 working. Comments explain what went wrong.