### PR TITLE
Bump Ubuntu and Mapserver. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update -y \
         wget \
     && apt-get clean
 
-RUN python3 -m pip install mappyfile==0.9.7
 
 # Enable these Apache modules
 RUN a2enmod actions cgid headers rewrite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,24 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 LABEL maintainer="datapunt@amsterdam.nl"
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ="Europe/Amsterdam"
 
-RUN apt-get update && apt-get install -my curl wget gnupg -y
-RUN apt install build-essential software-properties-common -y
-RUN add-apt-repository -y ppa:ubuntugis/ppa
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        apache2 \
+        cgi-mapserver \
+        curl \
+        gdal-bin \
+        gdal-data \
+        mapserver-bin \
+        python3-pip \
+        wget \
+    && apt-get clean
 
-RUN apt-get install -y gdal-bin gdal-data libgdal20
-RUN apt-get install -y apache2 apache2-utils libmapcache1 libapache2-mod-mapcache cgi-mapserver mapserver-bin
+RUN python3 -m pip install mappyfile==0.9.7
 
 # Enable these Apache modules
-RUN a2enmod actions cgi alias headers rewrite env
+RUN a2enmod actions cgid headers rewrite
 
 # Configure localhost in Apache
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
@@ -18,6 +27,7 @@ COPY docker/000-default.conf /etc/apache2/sites-available/
 COPY docker/docker-entrypoint.sh /bin
 
 COPY . /srv/mapserver/
+COPY epsg /usr/share/proj
 
 EXPOSE 80
 

--- a/epsg
+++ b/epsg
@@ -1,0 +1,18 @@
+# Amersfoort / RD New
+<28992> +proj=sterea +lat_0=52.1561605555556 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.4171,50.3319,465.5524,-0.398957388243134,0.343987817378283,-1.87740163998045,4.0725 +units=m +no_defs <>
+# ETRS89
+<4258> +proj=longlat +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +no_defs  <>
+# WGS 84
+<4326> +proj=longlat +datum=WGS84 +no_defs  <>
+# WGS 84 / Pseudo-Mercator
+<3857> +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs <>
+# ETRS89 / UTM zone 31N
+<25831> +proj=utm +zone=31 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs  <>
+# ETRS89 / UTM zone 32N
+<25832> +proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs  <>
+# ETRS89 / LCC Europe
+<3034> +proj=lcc +lat_1=35 +lat_2=65 +lat_0=52 +lon_0=10 +x_0=4000000 +y_0=2800000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs  <>
+# ETRS89 / LAEA Europe
+<3035> +proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs  <>
+# Amersfoort / RD New + NAP height
+<7415> +proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.4171,50.3319,465.5524,-0.398957,0.343988,-1.877402,4.0725 +units=m +vunits=m +no_defs  <>

--- a/projectiontest.map
+++ b/projectiontest.map
@@ -1,0 +1,44 @@
+MAP
+  NAME                      "projectiontest"
+  INCLUDE                   "header.inc"
+  DEBUG 1
+
+  SYMBOL
+    NAME "circle"
+    TYPE ellipse
+    FILLED true
+    POINTS
+      10 10
+    END 
+  END 
+
+  WEB
+    METADATA
+      "ows_title"           "Projection Test"
+      "ows_abstract"        "MAP-File om de projectie-parameters te testen."
+      "wms_extent"          "100000 450000 150000 500000"
+      "ows_enable_request"  "*"
+    END
+  END
+
+  LAYER
+    NAME                    "feature"
+    PROJECTION
+        "init=epsg:28992"
+    END
+    TYPE POINT
+    STATUS ON
+    FEATURE
+      POINTS
+        121369 486445
+      END
+    END
+    CLASS
+      STYLE
+        COLOR 229 77 3
+        SYMBOL "circle"
+        SIZE 6        
+      END
+    END
+  END
+END


### PR DESCRIPTION
Operating system updated to 22.04. MapServer minor version update picks up correct projection params from 'epsg' file.