### PR TITLE
CRLF/LF hack to ensure docker-compose works again on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,7 @@
 *.qix binary
 *.shp binary
 *.shx binary
+
+# Shell scripts used to build Docker images must use LF, even on Windows.
+# Be careful when editing these files from a Windows machine.
+docker/** binary


### PR DESCRIPTION
Without this, the scripts inside docker/ get checked out with CRLF endings on Windows. They then get copied into a Docker image with those endings and the script docker-entrypoint.sh borks:

    /usr/bin/env: 'bash\r': No such file or directory

Be careful when editing these files on Windows.