### PR TITLE
Add BBOX test to CI/CD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Check mapfiles
+name: Tests
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  check_maps:
+  check_mapfiles:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -53,3 +53,17 @@ jobs:
           bomen brk2 ondergrond ziektenplagenexotengroen \
           meldingen_huidige_jaar meldingen_vorige_jaar meldingen_indicatoren \
           monumenten hr
+
+  # Regression test. Asserts that we don't suffer from the MapServer 7.x
+  # bounding box bug https://github.com/MapServer/MapServer/issues/6478.
+  test_bbox:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run MapServer
+      run: docker-compose build map &&
+           docker-compose run -d -p "8383:80" map &&
+           sleep 3
+    - name: Projection test
+      run: curl 'http://localhost:8383/maps/projectiontest?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=feature&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326&bbox=4.89337404,52.36483743,4.89351768,52.36489491' |
+               jq '.features | if length > 0 then . else halt_error(1) end'


### PR DESCRIPTION
We previously ran into MapServer/MapServer#6478 when trying to upgrade our Ubuntu base image and added the file `epsg` as a hack to work around it in 20d7dc720b53366424f42f2769b31c9477b172a0. This adds a regression test for that upstream issue.

I have tested this with `COPY epsg /usr/share/proj` removed from `Dockerfile`, and that makes it fail.