### PR TITLE
Properly set geometry as MultiPolygon.

### DIFF
--- a/nieuwbouwplannen.map
+++ b/nieuwbouwplannen.map
@@ -5,7 +5,7 @@ MAP
     METADATA
       "ows_title"           "Nieuwbouwplannen"
       "ows_abstract"        "Nieuwbouwplannen woningbouw openbaar Amsterdam"
-      "ows_onlineresource"  "MAP_URL_REPLACE/maps/nieuwbouwplannen"
+      "ows_onlineresource"  "http://map/maps/nieuwbouwplannen"
     END
   END
 
@@ -29,7 +29,7 @@ MAP
       "wms_group_title"     "Woningbouwplannen"
       "gml_featureid"       "id"
       "gml_geometries"      "geometry"
-      "gml_geometry_type"   "polygon"
+      "gml_geometry_type"   "multipolygon"
       "gml_include_items"   "all"
       "gml_types"           "auto"
       "wms_include_items"   "all"
@@ -70,7 +70,7 @@ MAP
       "wms_group_title"     "Woningbouwplannen"
       "gml_featureid"       "id"
       "gml_geometries"      "geometry"
-      "gml_geometry_type"   "polygon"
+      "gml_geometry_type"   "multipolygon"
       "gml_include_items"   "all"
       "gml_types"           "auto"
       "wms_include_items"   "all"
@@ -111,7 +111,7 @@ MAP
       "wms_group_title"     "Woningbouwplannen"
       "gml_featureid"       "id"
       "gml_geometries"      "geometry"
-      "gml_geometry_type"   "polygon"
+      "gml_geometry_type"   "multipolygon"
       "gml_include_items"   "all"
       "gml_types"           "auto"
       "wms_include_items"   "all"
@@ -152,7 +152,7 @@ MAP
       "wms_group_title"     "Woningbouwplannen"
       "gml_featureid"       "id"
       "gml_geometries"      "geometry"
-      "gml_geometry_type"   "polygon"
+      "gml_geometry_type"   "multipolygon"
       "gml_include_items"   "all"
       "gml_types"           "auto"
       "wms_include_items"   "all"
@@ -193,7 +193,7 @@ MAP
       "wms_group_title"     "Woningbouwplannen"
       "gml_featureid"       "id"
       "gml_geometries"      "geometry"
-      "gml_geometry_type"   "polygon"
+      "gml_geometry_type"   "multipolygon"
       "gml_include_items"   "all"
       "gml_types"           "auto"
       "wms_include_items"   "all"


### PR DESCRIPTION
If a database table contains MultiPolygons, but MapServer is set to serve polygons, it returns multiple geometries for each feature. Now that MapServer is set to serve MultiPolygons for this layer instead, it properly returns one geometry for each feature, i.e. a MultiPolygon.