### PR TITLE
Improve template MAP file

### DIFF
--- a/.mapfile_template.txt
+++ b/.mapfile_template.txt
@@ -29,7 +29,7 @@ MAP
       "wms_group_title"     "Group naam"                                 # Sentence case naam in meervoud met eventuele afkorting in haakjes erachter
       "gml_featureid"       "id"                                         # Unique ID volgens het Amsterdam Schema
       "gml_geometries"      "geometry"
-      "gml_geometry_type"   "point"                                      # Gelijk aan de TYPE van de LAYER
+      "gml_geometry_type"   "point"                                      # Type gelijk aan database: (multi-) point/line/polygon
       "gml_include_items"   "all"                                        # Toon alle attributen in het GML antwoord (WMS én WFS)
       "gml_types"           "auto"
       "wms_include_items"   "all"                                        # Toon alle attributen in het CSV antwoord (WMS)

--- a/nieuwbouwplannen.map
+++ b/nieuwbouwplannen.map
@@ -5,7 +5,7 @@ MAP
     METADATA
       "ows_title"           "Nieuwbouwplannen"
       "ows_abstract"        "Nieuwbouwplannen woningbouw openbaar Amsterdam"
-      "ows_onlineresource"  "MAP_URL_REPLACE/maps/nieuwbouwplannen"
+      "ows_onlineresource"  "http://map/maps/nieuwbouwplannen"
     END
   END
 
@@ -29,7 +29,7 @@ MAP
       "wms_group_title"     "Woningbouwplannen"
       "gml_featureid"       "id"
       "gml_geometries"      "geometry"
-      "gml_geometry_type"   "polygon"
+      "gml_geometry_type"   "multipolygon"
       "gml_include_items"   "all"
       "gml_types"           "auto"
       "wms_include_items"   "all"
@@ -70,7 +70,7 @@ MAP
       "wms_group_title"     "Woningbouwplannen"
       "gml_featureid"       "id"
       "gml_geometries"      "geometry"
-      "gml_geometry_type"   "polygon"
+      "gml_geometry_type"   "multipolygon"
       "gml_include_items"   "all"
       "gml_types"           "auto"
       "wms_include_items"   "all"
@@ -111,7 +111,7 @@ MAP
       "wms_group_title"     "Woningbouwplannen"
       "gml_featureid"       "id"
       "gml_geometries"      "geometry"
-      "gml_geometry_type"   "polygon"
+      "gml_geometry_type"   "multipolygon"
       "gml_include_items"   "all"
       "gml_types"           "auto"
       "wms_include_items"   "all"
@@ -152,7 +152,7 @@ MAP
       "wms_group_title"     "Woningbouwplannen"
       "gml_featureid"       "id"
       "gml_geometries"      "geometry"
-      "gml_geometry_type"   "polygon"
+      "gml_geometry_type"   "multipolygon"
       "gml_include_items"   "all"
       "gml_types"           "auto"
       "wms_include_items"   "all"
@@ -193,7 +193,7 @@ MAP
       "wms_group_title"     "Woningbouwplannen"
       "gml_featureid"       "id"
       "gml_geometries"      "geometry"
-      "gml_geometry_type"   "polygon"
+      "gml_geometry_type"   "multipolygon"
       "gml_include_items"   "all"
       "gml_types"           "auto"
       "wms_include_items"   "all"


### PR DESCRIPTION
The `gml_geometry_type` meta tag in the MAP file must reflect the geometry type in the database.