### PR TITLE
non-root for mapserver, mapserver-private & jwt-proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,12 @@ RUN rm /etc/apache2/mods-enabled/alias.conf
 COPY docker/000-default.conf /etc/apache2/sites-available/
 COPY docker/docker-entrypoint.sh /bin
 
-COPY . /srv/mapserver/
+RUN useradd -M -U datapunt
+COPY . /srv/mapserver/ && chown -R datapunt:datapunt /srv/
 RUN rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj
 
 EXPOSE 80
 
+USER datapunt
 CMD /bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,10 @@ COPY epsg /usr/share/proj
 RUN usermod --non-unique --uid 999 www-data
 RUN groupmod -o -g 999 www-data
 RUN chmod 775 $(find /srv -type d)
-RUN mkdir /var/lock/apache2 && mkdir /var/run/apache2
+RUN mkdir /var/lock/apache2 && mkdir /var/run/apache2 && mkdir /var/log/apache2/
 # RUN chown -R datapunt:datapunt /srv/ && chown -R datapunt:datapunt /etc/apache2/ 
 RUN chown -R 999:999 /srv/ && chown -R 999:999 /etc/apache2/
-RUN chown -R 999:999 /var/lock/apache2 && chown -R 999:999 /var/run/apache2
+RUN chown -R 999:999 /var/lock/apache2 && chown -R 999:999 /var/run/apache2 && chown -R 999:999 /var/log/apache2/
 RUN rm -rf /srv/mapserver/private
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,11 @@ COPY epsg /usr/share/proj
 
 RUN useradd -M -u 999 -U datapunt
 RUN chmod 775 $(find /srv -type d)
-RUN chown -R datapunt:datapunt /srv/ && chown -R datapunt:datapunt /etc/apache2/ && chown -R datapunt:datapunt /var/lock/apache2
+RUN chown -R datapunt:datapunt /srv/ && chown -R datapunt:datapunt /etc/apache2/ 
 RUN rm -rf /srv/mapserver/private
 
 EXPOSE 80
 
 USER datapunt
+RUN mkdir /var/lock/apache2
 CMD /bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY docker/docker-entrypoint.sh /bin
 RUN useradd -M -U datapunt
 COPY . /srv/mapserver/ 
 RUN chmod 775 $(find /srv -type d)
+RUN ls -al /srv/mapserver/ && ls -al /srv/mapserver/connection/
 
 RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,13 @@ COPY epsg /usr/share/proj
 RUN usermod --non-unique --uid 999 www-data
 RUN groupmod -o -g 999 www-data
 RUN chmod 775 $(find /srv -type d)
+RUN mkdir /var/lock/apache2 && mkdir /var/run/apache2
 # RUN chown -R datapunt:datapunt /srv/ && chown -R datapunt:datapunt /etc/apache2/ 
-RUN chown -R 999:999 /srv/ && chown -R 999:999 /etc/apache2/ 
+RUN chown -R 999:999 /srv/ && chown -R 999:999 /etc/apache2/
+RUN chown -R 999:999 /var/lock/apache2 && chown -R 999:999 /var/run/apache2
 RUN rm -rf /srv/mapserver/private
 
 EXPOSE 80
 
 USER www-data
-RUN mkdir /var/lock/apache2 && mkdir /var/run/apache2
 CMD /bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ COPY epsg /usr/share/proj
 
 RUN useradd -M -u 999 -U datapunt
 RUN chmod 775 $(find /srv -type d)
-RUN chown -R datapunt:datapunt {/srv/,/etc/apache2/} && rm -rf /srv/mapserver/private
-
+RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
+RUN chown -R datapunt:datapunt /etc/apache2/
 EXPOSE 80
 
 USER datapunt

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY docker/docker-entrypoint.sh /bin
 
 RUN useradd -M -U datapunt
 COPY . /srv/mapserver/ 
+RUN mkdir /srv/mapserver/connection && chmod 755 /srv/mapserver/connection
 RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,8 @@ COPY epsg /usr/share/proj
 RUN useradd -M -u 999 -U datapunt
 RUN chmod 775 $(find /srv -type d)
 RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
-RUN chown -R datapunt:datapunt /etc/apache2/
+
 EXPOSE 80
 
 USER datapunt
-RUN mkdir /var/run/apache2
 CMD /bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ COPY epsg /usr/share/proj
 
 RUN useradd -M -u 999 -U datapunt
 RUN chmod 775 $(find /srv -type d)
-RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
+RUN chown -R datapunt:datapunt /srv/ && chown -R datapunt:datapunt /etc/apache2/
+RUN rm -rf /srv/mapserver/private
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,6 @@ RUN rm -rf /srv/mapserver/private
 
 EXPOSE 80
 
-USER datapunt
+USER www-data
 RUN mkdir /var/lock/apache2 && mkdir /var/run/apache2
 CMD /bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,5 @@ RUN chown -R datapunt:datapunt /etc/apache2/
 EXPOSE 80
 
 USER datapunt
+RUN mkdir /var/run/apache2
 CMD /bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY docker/docker-entrypoint.sh /bin
 
 RUN useradd -M -U datapunt
 COPY . /srv/mapserver/ 
-RUN chmod 755 $(find /srv -type d)
+RUN chmod 775 $(find /srv -type d)
 
 RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ COPY docker/000-default.conf /etc/apache2/sites-available/
 COPY docker/docker-entrypoint.sh /bin
 
 RUN useradd -M -U datapunt
-COPY . /srv/mapserver/ 
-RUN mkdir /srv/mapserver/connection && chmod 755 /srv/mapserver/connection
+COPY . /srv/mapserver/ && chmod 755 /srv/mapserver/connection
 RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,12 @@ RUN rm /etc/apache2/mods-enabled/alias.conf
 COPY docker/000-default.conf /etc/apache2/sites-available/
 COPY docker/docker-entrypoint.sh /bin
 
-RUN useradd -M -U datapunt
 COPY . /srv/mapserver/ 
-RUN chmod 775 $(find /srv -type d)
-RUN ls -al /srv/mapserver/ && ls -al /srv/mapserver/connection/
-
-RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj
+
+RUN useradd -M -U datapunt
+RUN chmod 775 $(find /srv -type d)
+RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY docker/docker-entrypoint.sh /bin
 
 RUN useradd -M -U datapunt
 COPY . /srv/mapserver/ 
-RUN /srv -type d -exec chmod 0755 {} \;
+RUN find /srv -type d -exec chmod 0755 {} \;
 RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ COPY docker/000-default.conf /etc/apache2/sites-available/
 COPY docker/docker-entrypoint.sh /bin
 
 RUN useradd -M -U datapunt
-COPY . /srv/mapserver/ && chmod 755 /srv/mapserver/connection
+COPY . /srv/mapserver/ 
+RUN chmod 755 /srv/mapserver/connection
 RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ COPY epsg /usr/share/proj
 # set apache user id matching ctr user id
 RUN usermod --non-unique --uid 999 www-data
 RUN groupmod -o -g 999 www-data
-# RUN chmod 775 $(find /srv -type d)
 RUN mkdir /var/lock/apache2 && mkdir /var/run/apache2 
 RUN chown -R 999:999 /var/lock/apache2 && chown -R 999:999 /var/run/apache2 && chown -R 999:999 /var/log/apache2/
 RUN chown -R 999:999 /srv/ && chown -R 999:999 /etc/apache2/

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY docker/docker-entrypoint.sh /bin
 COPY . /srv/mapserver/ 
 COPY epsg /usr/share/proj
 
-RUN useradd -M -U datapunt
+RUN useradd -M -u 999 -U datapunt
 RUN chmod 775 $(find /srv -type d)
 RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN chown -R 999:999 /srv/ && chown -R 999:999 /etc/apache2/
 RUN chown -R 999:999 /var/lock/apache2 && chown -R 999:999 /var/run/apache2
 RUN rm -rf /srv/mapserver/private
 
-EXPOSE 80
+EXPOSE 8080
 
 USER www-data
 CMD /bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ COPY docker/docker-entrypoint.sh /bin
 
 RUN useradd -M -U datapunt
 COPY . /srv/mapserver/ 
-RUN find /srv -type d -exec chmod 0755 {} \;
+RUN find /srv/mapserver -type d -exec chmod 0755 {} \;
+RUN chmod 0755 /srv/mapserver/connection;
 RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY docker/docker-entrypoint.sh /bin
 
 RUN useradd -M -U datapunt
 COPY . /srv/mapserver/ 
-RUN chmod 0755 /tmp/chmod/{/srv,/srv/mapserver/,/srv/mapserver/connection}
+RUN chmod 0755 /srv/{mapserver,mapserver/connection}
 
 RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY docker/docker-entrypoint.sh /bin
 
 RUN useradd -M -U datapunt
 COPY . /srv/mapserver/ 
-RUN chmod 0755 /srv/{mapserver,mapserver/connection}
+RUN chmod 755 $(find /srv -type d)
 
 RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ COPY docker/docker-entrypoint.sh /bin
 
 RUN useradd -M -U datapunt
 COPY . /srv/mapserver/ 
-RUN find /srv/mapserver -type d -exec chmod 0755 {} \;
-RUN chmod 0755 /srv/mapserver/connection;
+RUN chmod 0755 /tmp/chmod/{/srv,/srv/mapserver/,/srv/mapserver/connection}
+
 RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY epsg /usr/share/proj
 
 RUN useradd -M -u 999 -U datapunt
 RUN chmod 775 $(find /srv -type d)
-RUN chown -R datapunt:datapunt /srv/ && chown -R datapunt:datapunt /etc/apache2/
+RUN chown -R datapunt:datapunt /srv/ && chown -R datapunt:datapunt /etc/apache2/ && chown -R datapunt:datapunt /var/lock/apache2
 RUN rm -rf /srv/mapserver/private
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,10 @@ RUN rm /etc/apache2/mods-enabled/alias.conf
 COPY docker/000-default.conf /etc/apache2/sites-available/
 COPY docker/docker-entrypoint.sh /bin
 
-RUN useradd -M -U datapunt
-COPY . /srv/mapserver/ && chown -R datapunt:datapunt /srv/
+COPY . /srv/mapserver/
 RUN rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj
 
 EXPOSE 80
 
-USER datapunt
 CMD /bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY docker/docker-entrypoint.sh /bin
 
 RUN useradd -M -U datapunt
 COPY . /srv/mapserver/ 
-RUN chmod 755 /srv/mapserver/connection
+RUN /srv -type d -exec chmod 0755 {} \;
 RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,16 @@ COPY docker/docker-entrypoint.sh /bin
 COPY . /srv/mapserver/ 
 COPY epsg /usr/share/proj
 
-RUN useradd -M -u 999 -U datapunt
+# RUN useradd -M -u 999 -U datapunt
+RUN usermod --non-unique --uid 999 www-data
+RUN groupmod --non-unique --uid 999 www-data
 RUN chmod 775 $(find /srv -type d)
-RUN chown -R datapunt:datapunt /srv/ && chown -R datapunt:datapunt /etc/apache2/ 
+# RUN chown -R datapunt:datapunt /srv/ && chown -R datapunt:datapunt /etc/apache2/ 
+RUN chown -R 999:999 /srv/ && chown -R 999:999 /etc/apache2/ 
 RUN rm -rf /srv/mapserver/private
 
 EXPOSE 80
 
 USER datapunt
-RUN mkdir /var/lock/apache2
+RUN mkdir /var/lock/apache2 && mkdir /var/run/apache2
 CMD /bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY epsg /usr/share/proj
 RUN usermod --non-unique --uid 999 www-data
 RUN groupmod -o -g 999 www-data
 RUN chmod 775 $(find /srv -type d)
-RUN mkdir /var/lock/apache2 && mkdir /var/run/apache2 && mkdir /var/log/apache2/
+RUN mkdir /var/lock/apache2 && mkdir /var/run/apache2 
 # RUN chown -R datapunt:datapunt /srv/ && chown -R datapunt:datapunt /etc/apache2/ 
 RUN chown -R 999:999 /srv/ && chown -R 999:999 /etc/apache2/
 RUN chown -R 999:999 /var/lock/apache2 && chown -R 999:999 /var/run/apache2 && chown -R 999:999 /var/log/apache2/

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY epsg /usr/share/proj
 
 RUN useradd -M -u 999 -U datapunt
 RUN chmod 775 $(find /srv -type d)
-RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
+RUN chown -R datapunt:datapunt {/srv/,/etc/apache2/} && rm -rf /srv/mapserver/private
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY epsg /usr/share/proj
 
 # RUN useradd -M -u 999 -U datapunt
 RUN usermod --non-unique --uid 999 www-data
-RUN groupmod --non-unique --uid 999 www-data
+RUN groupmod -o -g 999 www-data
 RUN chmod 775 $(find /srv -type d)
 # RUN chown -R datapunt:datapunt /srv/ && chown -R datapunt:datapunt /etc/apache2/ 
 RUN chown -R 999:999 /srv/ && chown -R 999:999 /etc/apache2/ 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,13 @@ COPY docker/docker-entrypoint.sh /bin
 COPY . /srv/mapserver/ 
 COPY epsg /usr/share/proj
 
-# RUN useradd -M -u 999 -U datapunt
+# set apache user id matching ctr user id
 RUN usermod --non-unique --uid 999 www-data
 RUN groupmod -o -g 999 www-data
-RUN chmod 775 $(find /srv -type d)
+# RUN chmod 775 $(find /srv -type d)
 RUN mkdir /var/lock/apache2 && mkdir /var/run/apache2 
-# RUN chown -R datapunt:datapunt /srv/ && chown -R datapunt:datapunt /etc/apache2/ 
-RUN chown -R 999:999 /srv/ && chown -R 999:999 /etc/apache2/
 RUN chown -R 999:999 /var/lock/apache2 && chown -R 999:999 /var/run/apache2 && chown -R 999:999 /var/log/apache2/
+RUN chown -R 999:999 /srv/ && chown -R 999:999 /etc/apache2/
 RUN rm -rf /srv/mapserver/private
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,12 @@ RUN rm /etc/apache2/mods-enabled/alias.conf
 COPY docker/000-default.conf /etc/apache2/sites-available/
 COPY docker/docker-entrypoint.sh /bin
 
-COPY . /srv/mapserver/
-RUN rm -rf /srv/mapserver/private
+RUN useradd -M -U datapunt
+COPY . /srv/mapserver/ 
+RUN chown -R datapunt:datapunt /srv/ && rm -rf /srv/mapserver/private
 COPY epsg /usr/share/proj
 
 EXPOSE 80
 
+USER datapunt
 CMD /bin/docker-entrypoint.sh

--- a/Dockerfile.private
+++ b/Dockerfile.private
@@ -11,4 +11,5 @@ USER root
 RUN rm -rf /srv/mapserver/private
 COPY /private/ /srv/mapserver/
 RUN chown -R 999:999 /srv/ && chown -R 999:999 /etc/apache2/
+USER www-data
 

--- a/Dockerfile.private
+++ b/Dockerfile.private
@@ -10,3 +10,5 @@ USER root
 # private variety.
 RUN rm -rf /srv/mapserver/private
 COPY /private/ /srv/mapserver/
+RUN chown -R 999:999 /srv/ && chown -R 999:999 /etc/apache2/
+

--- a/Dockerfile.private
+++ b/Dockerfile.private
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 
 # used by make_mapfile_config.py to include private mapfiles in sld config
 ENV ACCESS_SCOPE private
-
+USER root
 # Copy private mapfiles into the root dir so they will be served
 # Any maps that have a public and private variety will serve the
 # private variety.

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -20,9 +20,12 @@ DATASERVICES_DB_USER=${DATASERVICES_DB_USER:-${DATASERVICES_DB_NAME}}
 DATASERVICES_DB_PASSWORD_PATH=${DATASERVICES_DB_PASSWORD_PATH:-'/mnt/secrets-store/mapserver-public'}
 
 echo Creating configuration files
-id
-ls -al /srv/mapserver/
-ls -al /srv/mapserver/connection/
+id; whoami
+cat > /var/tmp/yay << EOF
+HERE
+EOF
+
+ls -al /var/tmp
 
 cat > /srv/mapserver/connection/panorama.inc <<EOF
 CONNECTIONTYPE postgis

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -22,6 +22,7 @@ DATASERVICES_DB_PASSWORD_PATH=${DATASERVICES_DB_PASSWORD_PATH:-'/mnt/secrets-sto
 echo Creating configuration files
 
 ls -al /srv/mapserver/
+ls -al /srv/mapserver/connection/
 
 cat > /srv/mapserver/connection/panorama.inc <<EOF
 CONNECTIONTYPE postgis

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,7 +2,6 @@
 
 set -e
 set -u
-set -x
 
 PANORAMA_DB_PORT=${PANORAMA_DB_PORT:-5432}
 PANORAMA_DB_NAME=${PANORAMA_DB_NAME:-panorama}
@@ -20,13 +19,6 @@ DATASERVICES_DB_USER=${DATASERVICES_DB_USER:-${DATASERVICES_DB_NAME}}
 DATASERVICES_DB_PASSWORD_PATH=${DATASERVICES_DB_PASSWORD_PATH:-'/mnt/secrets-store/mapserver-public'}
 
 echo Creating configuration files
-id
-cat > /var/tmp/yay << EOF
-HERE
-EOF
-
-ls -al /var/tmp
-cat /etc/apache2/envvars
 
 cat > /srv/mapserver/connection/panorama.inc <<EOF
 CONNECTIONTYPE postgis
@@ -75,5 +67,4 @@ echo Starting server
 # Apache gets grumpy about PID files pre-existing
 rm -f /var/run/apache2/apache2.pid
 
-# export APACHE_RUN_USER=#$(id -u)
 apachectl -D FOREGROUND

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -72,4 +72,5 @@ echo Starting server
 # Apache gets grumpy about PID files pre-existing
 rm -f /var/run/apache2/apache2.pid
 
+export APACHE_RUN_USER=#$(id -u)
 apachectl -D FOREGROUND

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -20,7 +20,7 @@ DATASERVICES_DB_USER=${DATASERVICES_DB_USER:-${DATASERVICES_DB_NAME}}
 DATASERVICES_DB_PASSWORD_PATH=${DATASERVICES_DB_PASSWORD_PATH:-'/mnt/secrets-store/mapserver-public'}
 
 echo Creating configuration files
-id; whoami
+id
 cat > /var/tmp/yay << EOF
 HERE
 EOF

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -20,7 +20,7 @@ DATASERVICES_DB_USER=${DATASERVICES_DB_USER:-${DATASERVICES_DB_NAME}}
 DATASERVICES_DB_PASSWORD_PATH=${DATASERVICES_DB_PASSWORD_PATH:-'/mnt/secrets-store/mapserver-public'}
 
 echo Creating configuration files
-
+id
 ls -al /srv/mapserver/
 ls -al /srv/mapserver/connection/
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -23,8 +23,7 @@ echo Creating configuration files
 
 mkdir -p /srv/mapserver/connection
 ls -al /srv/mapserver/
-
-echo "yay" | tee /srv/mapserver/connection/yay
+find /srv/mapserver -type d -exec chmod 0755 {} \;
 
 cat > /srv/mapserver/connection/panorama.inc <<EOF
 CONNECTIONTYPE postgis

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -53,6 +53,8 @@ EOF
 #      https://serverfault.com/questions/711168/writing-apache2-logs-to-stdout-stderr
 sed -i 's/ErrorLog .*/ErrorLog \/dev\/stderr/' /etc/apache2/apache2.conf
 sed -i 's/Timeout 300/Timeout 600/' /etc/apache2/apache2.conf
+# set listen port to non-privileged port
+sed -i '0,/Listen [0-9]*/s//Listen 8080/' /etc/apache2/ports.conf
 
 # Replace actual location of the mapserver depending on the environment   
 shopt -s globstar nullglob

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -72,5 +72,5 @@ echo Starting server
 # Apache gets grumpy about PID files pre-existing
 rm -f /var/run/apache2/apache2.pid
 
-export APACHE_RUN_USER=#$(id -u)
+# export APACHE_RUN_USER=#$(id -u)
 apachectl -D FOREGROUND

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -55,6 +55,7 @@ sed -i 's/ErrorLog .*/ErrorLog \/dev\/stderr/' /etc/apache2/apache2.conf
 sed -i 's/Timeout 300/Timeout 600/' /etc/apache2/apache2.conf
 # set listen port to non-privileged port
 sed -i '0,/Listen [0-9]*/s//Listen 8080/' /etc/apache2/ports.conf
+sed -i s/\<VirtualHost.*/VirtualHost\ \*\:8080/ /etc/apache2/sites-enabled/000-default.conf
 
 # Replace actual location of the mapserver depending on the environment   
 shopt -s globstar nullglob

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,6 +2,7 @@
 
 set -e
 set -u
+set -x
 
 PANORAMA_DB_PORT=${PANORAMA_DB_PORT:-5432}
 PANORAMA_DB_NAME=${PANORAMA_DB_NAME:-panorama}
@@ -21,6 +22,9 @@ DATASERVICES_DB_PASSWORD_PATH=${DATASERVICES_DB_PASSWORD_PATH:-'/mnt/secrets-sto
 echo Creating configuration files
 
 mkdir -p /srv/mapserver/connection
+ls -al /srv/mapserver/
+
+echo "yay" | tee /srv/mapserver/yay
 
 cat > /srv/mapserver/connection/panorama.inc <<EOF
 CONNECTIONTYPE postgis

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -55,7 +55,7 @@ sed -i 's/ErrorLog .*/ErrorLog \/dev\/stderr/' /etc/apache2/apache2.conf
 sed -i 's/Timeout 300/Timeout 600/' /etc/apache2/apache2.conf
 # set listen port to non-privileged port
 sed -i '0,/Listen [0-9]*/s//Listen 8080/' /etc/apache2/ports.conf
-sed -i s/\<VirtualHost.*/\<VirtualHost\ \*\:8080/ /etc/apache2/sites-enabled/000-default.conf
+sed -i s/\<VirtualHost.*/\<VirtualHost\ \*\:8080\>/ /etc/apache2/sites-enabled/000-default.conf
 
 # Replace actual location of the mapserver depending on the environment   
 shopt -s globstar nullglob

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -21,9 +21,7 @@ DATASERVICES_DB_PASSWORD_PATH=${DATASERVICES_DB_PASSWORD_PATH:-'/mnt/secrets-sto
 
 echo Creating configuration files
 
-mkdir -p /srv/mapserver/connection
 ls -al /srv/mapserver/
-find /srv/mapserver -type d -exec chmod 0755 {} \;
 
 cat > /srv/mapserver/connection/panorama.inc <<EOF
 CONNECTIONTYPE postgis

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -55,7 +55,7 @@ sed -i 's/ErrorLog .*/ErrorLog \/dev\/stderr/' /etc/apache2/apache2.conf
 sed -i 's/Timeout 300/Timeout 600/' /etc/apache2/apache2.conf
 # set listen port to non-privileged port
 sed -i '0,/Listen [0-9]*/s//Listen 8080/' /etc/apache2/ports.conf
-sed -i s/\<VirtualHost.*/VirtualHost\ \*\:8080/ /etc/apache2/sites-enabled/000-default.conf
+sed -i s/\<VirtualHost.*/\<VirtualHost\ \*\:8080/ /etc/apache2/sites-enabled/000-default.conf
 
 # Replace actual location of the mapserver depending on the environment   
 shopt -s globstar nullglob

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -26,6 +26,7 @@ HERE
 EOF
 
 ls -al /var/tmp
+cat /etc/apache2/envvars
 
 cat > /srv/mapserver/connection/panorama.inc <<EOF
 CONNECTIONTYPE postgis

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -24,7 +24,7 @@ echo Creating configuration files
 mkdir -p /srv/mapserver/connection
 ls -al /srv/mapserver/
 
-echo "yay" | tee /srv/mapserver/yay
+echo "yay" | tee /srv/mapserver/connection/yay
 
 cat > /srv/mapserver/connection/panorama.inc <<EOF
 CONNECTIONTYPE postgis

--- a/jwtproxy/Dockerfile.prd
+++ b/jwtproxy/Dockerfile.prd
@@ -6,7 +6,14 @@ WORKDIR /app
 COPY src jwtproxy 
 COPY requirements.txt .
 
+RUN usermod --non-unique --uid 999 proxy
+RUN groupmod -o -g 999 proxy
+RUN chown -R 999:999 /app
+
 RUN pip install supervisor
 RUN pip install -r requirements.txt
+
 EXPOSE 8000
+
+USER proxy
 ENTRYPOINT [ "/bin/sh", "-c", "/usr/local/bin/supervisord -n"]

--- a/jwtproxy/supervisord.conf
+++ b/jwtproxy/supervisord.conf
@@ -2,7 +2,7 @@
 loglevel = debug ; when set to debug, supervisord will include stderr/stdout of child processes
 logfile = /dev/stdout
 logfile_maxbytes = 0
-user=root
+user=proxy
 
 [unix_http_server]
 file = /tmp/supervisord.sock


### PR DESCRIPTION
add changes to run mapserver containers with non-privileged users. Tested with aks.

TODO: Might need follow up for docker-compose files for local dev deploys.
