### PR TITLE
Ls/non root compose revert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update -y \
         curl \
         gdal-bin \
         gdal-data \
-        gosu \
         mapserver-bin \
         python3-pip \
         wget \
@@ -37,4 +36,5 @@ RUN rm -rf /srv/mapserver/private
 
 EXPOSE 8080
 
-CMD /bin/docker-entrypoint.sh
+USER www-data
+CMD /bin/docker-entrypoint.shp

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ RUN rm -rf /srv/mapserver/private
 EXPOSE 8080
 
 USER www-data
-CMD /bin/docker-entrypoint.shp
+CMD /bin/docker-entrypoint.sh

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -27,8 +27,6 @@ CONNECTION "host=${DATASERVICES_DB_HOST} dbname=${DATASERVICES_DB_NAME} user=${D
 PROCESSING "CLOSE_CONNECTION=DEFER"
 EOF
 
-gosu www-data bash
-
 # Configure apache to redirect errors to stderr.
 # The mapserver will redirect errors to apache errorstream (see header.inc and private/header.inc)
 # and apache will then redirect this to stderr, which will then be redirected to syslog/kibana.


### PR DESCRIPTION
compose solution with gosu breaks deploy since container can not switch user after container create when deployed as non-root user.

tested on TEST