### PR TITLE
bump yarl to 1.12.0

### DIFF
--- a/jwtproxy/requirements.txt
+++ b/jwtproxy/requirements.txt
@@ -12,5 +12,5 @@ jwcrypto==1.5.6
 multidict==6.0.2
 pycparser==2.21
 wrapt==1.14.1
-yarl==1.8.1
+yarl===1.12.0
 opencensus-ext-azure==1.1.8


### PR DESCRIPTION
The conflict is caused by:
    The user requested yarl==1.8.1
    aiohttp 3.10.11 depends on yarl<2.0 and >=1.12.0
