### PR TITLE
Changes to enable multiple styles for reference map

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -90,6 +90,7 @@ services:
       - ./tools/:/srv/mapserver/tools/
       - ./symbols/:/srv/mapserver/symbols/
       - ./fonts/:/srv/mapserver/fonts/
+      - ./sld/:/srv/mapserver/sld/
       - ./connection/:/srv/mapserver/connection/
       - ./private:/srv/mapserver/
 
@@ -122,5 +123,6 @@ services:
       - ./tools/:/srv/mapserver/tools/
       - ./symbols/:/srv/mapserver/symbols/
       - ./fonts/:/srv/mapserver/fonts/
+      - ./sld/:/srv/mapserver/sld/
       - ./connection/:/srv/mapserver/connection/
       - ./referentiekaarten/:/srv/mapserver/

--- a/sld/kbk10_light.xml
+++ b/sld/kbk10_light.xml
@@ -417,24 +417,7 @@
     </UserStyle>
   </NamedLayer>
   <NamedLayer>
-    <Name>TRN_binnentuin-case</Name>
-    <UserStyle>
-      <FeatureTypeStyle>
-        <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>8000</MaxScaleDenominator>
-          <PolygonSymbolizer>
-            <Stroke>
-              <CssParameter name="stroke">#C9C7C2</CssParameter>
-              <CssParameter name="stroke-width">1.5</CssParameter>
-            </Stroke>
-          </PolygonSymbolizer>
-        </Rule>
-      </FeatureTypeStyle>
-    </UserStyle>
-  </NamedLayer>
-  <NamedLayer>
-    <Name>TRN_binnentuin-fill</Name>
+    <Name>TRN_binnentuin</Name>
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
@@ -444,6 +427,10 @@
             <Fill>
               <CssParameter name="fill">#E5EBD8</CssParameter>
             </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#C9C7C2</CssParameter>
+              <CssParameter name="stroke-width">1.5</CssParameter>
+            </Stroke>
           </PolygonSymbolizer>
         </Rule>
       </FeatureTypeStyle>
@@ -871,12 +858,6 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:PropertyName>TYPEWEG</ogc:PropertyName>
-              <ogc:Literal>autosnelweg</ogc:Literal>
-            </ogc:PropertyIsEqualTo>
-          </ogc:Filter>
           <MinScaleDenominator>8000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
@@ -887,12 +868,6 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:PropertyName>TYPEWEG</ogc:PropertyName>
-              <ogc:Literal>autosnelweg</ogc:Literal>
-            </ogc:PropertyIsEqualTo>
-          </ogc:Filter>
           <MinScaleDenominator>3500</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
@@ -910,12 +885,6 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:PropertyName>TYPEWEG</ogc:PropertyName>
-              <ogc:Literal>autosnelweg</ogc:Literal>
-            </ogc:PropertyIsEqualTo>
-          </ogc:Filter>
           <MinScaleDenominator>8000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
@@ -926,12 +895,6 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:PropertyName>TYPEWEG</ogc:PropertyName>
-              <ogc:Literal>autosnelweg</ogc:Literal>
-            </ogc:PropertyIsEqualTo>
-          </ogc:Filter>
           <MinScaleDenominator>3500</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>

--- a/sld/kbk10_zw.xml
+++ b/sld/kbk10_zw.xml
@@ -417,33 +417,20 @@
     </UserStyle>
   </NamedLayer>
   <NamedLayer>
-    <Name>TRN_binnentuin-case</Name>
+    <Name>TRN_binnentuin</Name>
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>3500</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#F0F0F0</CssParameter>
+            </Fill>
             <Stroke>
               <CssParameter name="stroke">#C9C7C2</CssParameter>
               <CssParameter name="stroke-width">1.5</CssParameter>
             </Stroke>
-          </PolygonSymbolizer>
-        </Rule>
-      </FeatureTypeStyle>
-    </UserStyle>
-  </NamedLayer>
-  <NamedLayer>
-    <Name>TRN_binnentuin-fill</Name>
-    <UserStyle>
-      <FeatureTypeStyle>
-        <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>10000</MaxScaleDenominator>
-          <PolygonSymbolizer>
-            <Fill>
-              <CssParameter name="fill">#F0F0F0</CssParameter>
-            </Fill>
           </PolygonSymbolizer>
         </Rule>
       </FeatureTypeStyle>
@@ -871,12 +858,6 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:PropertyName>TYPEWEG</ogc:PropertyName>
-              <ogc:Literal>autosnelweg</ogc:Literal>
-            </ogc:PropertyIsEqualTo>
-          </ogc:Filter>
           <MinScaleDenominator>8000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
@@ -887,12 +868,6 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:PropertyName>TYPEWEG</ogc:PropertyName>
-              <ogc:Literal>autosnelweg</ogc:Literal>
-            </ogc:PropertyIsEqualTo>
-          </ogc:Filter>
           <MinScaleDenominator>3500</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>
@@ -910,12 +885,6 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:PropertyName>TYPEWEG</ogc:PropertyName>
-              <ogc:Literal>autosnelweg</ogc:Literal>
-            </ogc:PropertyIsEqualTo>
-          </ogc:Filter>
           <MinScaleDenominator>8000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
@@ -926,12 +895,6 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <ogc:Filter>
-            <ogc:PropertyIsEqualTo>
-              <ogc:PropertyName>TYPEWEG</ogc:PropertyName>
-              <ogc:Literal>autosnelweg</ogc:Literal>
-            </ogc:PropertyIsEqualTo>
-          </ogc:Filter>
           <MinScaleDenominator>3500</MinScaleDenominator>
           <MaxScaleDenominator>8000</MaxScaleDenominator>
           <LineSymbolizer>


### PR DESCRIPTION
Added the 'sld' directory to the container and also corrected the SLDs to style the map based on Top10NL data in black&white (zw) and light (light) variants.