### PR TITLE
Don't log requests from MapProxy.

### DIFF
--- a/docker/000-default.conf
+++ b/docker/000-default.conf
@@ -24,7 +24,8 @@
   # LogLevel debug rewrite:trace8
 
   ErrorLog /dev/stdout
-  CustomLog /dev/stdout combined
+  SetEnvIf Request_URI ^/tiled|sld/ tiling
+  CustomLog /dev/stdout combined env=!tiling
 
   <Directory /srv/mapserver>
       Require all denied


### PR DESCRIPTION
MapProxy sends millions of requests to the `/tiled/` endpoint of MapServer when it is making map tiles. It's just a waste of time and disk space if MapServer is logging all these requests.