### PR TITLE
Align zoom levels and visualisation of BRT/BGT/BAG for topographic reference maps.

### DIFF
--- a/referentiekaarten/bgt.map
+++ b/referentiekaarten/bgt.map
@@ -6,1091 +6,952 @@
 #==============================================================================
 
 MAP
-	NAME                      "bgt"
-	INCLUDE                   "header.inc"
+    NAME                      "bgt"
+    INCLUDE                   "header.inc"
 
-	WEB
-		METADATA
-			"ows_title"           "bgt"
-			"ows_abstract"        "Basisregistratie Grootschalige Topografie"
-			"ows_onlineresource"  "MAP_URL_REPLACE/tiled/bgt"
-		END
-	END
+    WEB
+        METADATA
+            "ows_title"           "bgt"
+            "ows_abstract"        "Basisregistratie Grootschalige Topografie"
+            "ows_onlineresource"  "MAP_URL_REPLACE/tiled/bgt"
+        END
+    END
 
-	IMAGECOLOR                "#FEFAFA"
-
-
-#==============================================================================
-# VLAKKEN
-#==============================================================================
+    IMAGECOLOR                "#FEFAFA"
 
 #==============================================================================
 # WATER
 #==============================================================================
 
 # Water 0
-	LAYER
-		NAME                    waterdeel_vlak0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_waterdelen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"           "waterdeel_vlak0"
-			"wms_group_title"     "hoogte0"
-		END
-		CLASS
-			MAXSCALEDENOM         3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR               "#95C6D5"
-				OUTLINECOLOR        "#95C6D5"
-			END
-		END
-	END
 
+    LAYER
+        NAME                    waterdeel_vlak0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, id from public.bgt_waterdelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "waterdeel_vlak0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#95C6D5"
+                OUTLINECOLOR    "#95C6D5"
+            END
+        END
+    END
 
+    #-----------------------------------------------------------------------------
+    # Terreindeel 0 (oever, slootkant))
 
+    LAYER
+        NAME                    ondersteunendewaterdelen_vlak0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, id from public.bgt_ondersteunendewaterdelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "ondersteunendewaterdelen_vlak0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#F9F9E7"
+                OUTLINECOLOR    "#F9F9E7"
+                WIDTH           0.1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
 #==============================================================================
 ## HOOGTELIGGING 0
 #==============================================================================
 
-# Terreindeel (begroeid))
-	LAYER
-		NAME                    begroeideterreindelen_vlak0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_begroeideterreindelen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_fysiek_voorkomen"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		FILTER (("[bgt_fysiek_voorkomen]" = "erf") Or ("[bgt_fysiek_voorkomen]" = "zand") Or ("[bgt_fysiek_voorkomen]" = "onverhard") Or ("[bgt_fysiek_voorkomen]" = "houtwal") Or ("[bgt_fysiek_voorkomen]" = "kwelder") Or ("[bgt_fysiek_voorkomen]" = "heide") Or ("[bgt_fysiek_voorkomen]" = "strekdam") Or ("[bgt_fysiek_voorkomen]" = "rietland") Or ("[bgt_fysiek_voorkomen]" = "gesloten verharding") Or ("[bgt_fysiek_voorkomen]" = "half verhard" ) Or ("[bgt_fysiek_voorkomen]" = "perron") Or ("[bgt_fysiek_voorkomen]" = "transitie") Or ("[bgt_fysiek_voorkomen]" = "open verharding" ) Or ("[bgt_fysiek_voorkomen]" = "groenvoorziening") Or ("[bgt_fysiek_voorkomen]" = "struiken") Or ("[bgt_fysiek_voorkomen]" = "grasland overig" ) Or ("[bgt_fysiek_voorkomen]" = "grasland agrarisch" ) Or ("[bgt_fysiek_voorkomen]" = "naaldbos") Or ("[bgt_fysiek_voorkomen]" = "fruitteelt") Or ("[bgt_fysiek_voorkomen]" = "loofbos") Or ("[bgt_fysiek_voorkomen]" = "bouwland") Or ("[bgt_fysiek_voorkomen]" = "gemengd bos" ) Or ("[bgt_fysiek_voorkomen]" = "moeras") Or ("[bgt_fysiek_voorkomen]" = "boomteelt") Or ("[bgt_fysiek_voorkomen]" = "oever, slootkant") )
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "begroeideterreindelen_vlak0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			EXPRESSION      {erf,onverhard,rietland,zand,houtwal}
-			STYLE
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   2000
-				COLOR         "#F9F9E7"
-				OUTLINECOLOR  "#F9F9E7"
-			END
-			STYLE
-			MAXSCALEDENOM   2000
-			MINSCALEDENOM   0
-				COLOR         "#F9F9E7"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      {groenvoorziening,grasland overig,grasland agrarisch,struiken}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#DCEACF"
-				OUTLINECOLOR  "#DCEACF"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      /^(oever|kwelder).*$/
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#F9F9E7"
-				OUTLINECOLOR  "#F9F9E7"
-				WIDTH         0.1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      {open verharding,gesloten verharding,transitie,half verhard,perron,strekdam}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#FFFFFF"
-				OUTLINECOLOR  "#FFFFFF"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      {loofbos,gemengd bos,bouwland,moeras,fruitteelt,boomteelt,naaldbos}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#CBE0B8"
-				OUTLINECOLOR  "#CBE0B8"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      "heide"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#ddd6e5"
-				OUTLINECOLOR  "#ddd6e5"
-				WIDTH         0.1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+# Terreindeel 0 (begroeid))
 
-# Terreindeel (onbegroeid)
-LAYER
-	NAME                    onbegroeideterreindelen_vlak0
-	GROUP                   hoogte0
-	INCLUDE                 "connection/dataservices.inc"
-	DATA                    "geometrie FROM (select * from public.bgt_onbegroeideterreindelen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-	TYPE                    POLYGON
-	CLASSITEM               "bgt_fysiek_voorkomen"
-	MAXSCALEDENOM           3500
-	MINSCALEDENOM			0
-	FILTER (("[bgt_fysiek_voorkomen]" = "erf") Or ("[bgt_fysiek_voorkomen]" = "zand") Or ("[bgt_fysiek_voorkomen]" = "onverhard") Or ("[bgt_fysiek_voorkomen]" = "houtwal") Or ("[bgt_fysiek_voorkomen]" = "kwelder") Or ("[bgt_fysiek_voorkomen]" = "heide") Or ("[bgt_fysiek_voorkomen]" = "strekdam") Or ("[bgt_fysiek_voorkomen]" = "rietland") Or ("[bgt_fysiek_voorkomen]" = "gesloten verharding") Or ("[bgt_fysiek_voorkomen]" = "half verhard" ) Or ("[bgt_fysiek_voorkomen]" = "perron") Or ("[bgt_fysiek_voorkomen]" = "transitie") Or ("[bgt_fysiek_voorkomen]" = "open verharding" ) Or ("[bgt_fysiek_voorkomen]" = "groenvoorziening") Or ("[bgt_fysiek_voorkomen]" = "struiken") Or ("[bgt_fysiek_voorkomen]" = "grasland overig" ) Or ("[bgt_fysiek_voorkomen]" = "grasland agrarisch" ) Or ("[bgt_fysiek_voorkomen]" = "naaldbos") Or ("[bgt_fysiek_voorkomen]" = "fruitteelt") Or ("[bgt_fysiek_voorkomen]" = "loofbos") Or ("[bgt_fysiek_voorkomen]" = "bouwland") Or ("[bgt_fysiek_voorkomen]" = "gemengd bos" ) Or ("[bgt_fysiek_voorkomen]" = "moeras") Or ("[bgt_fysiek_voorkomen]" = "boomteelt") Or ("[bgt_fysiek_voorkomen]" = "oever, slootkant") )
-	PROJECTION
-		"init=epsg:28992"
-	END
-	METADATA
-		"wms_title"            "onbegroeideterreindelen_vlak0"
-		"wms_group_title"      "hoogte0"
-	END
-	CLASS
-		EXPRESSION      {erf,onverhard,rietland,zand,houtwal}
-		STYLE
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM   2000
-			COLOR         "#F9F9E7"
-			OUTLINECOLOR  "#F9F9E7"
-		END
-		STYLE
-		MAXSCALEDENOM   2000
-		MINSCALEDENOM   0
-			COLOR         "#F9F9E7"
-			OUTLINECOLOR  "#C9C7C2"
-			WIDTH         0.5
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-	END
-	CLASS
-		EXPRESSION      {groenvoorziening,grasland overig,grasland agrarisch,struiken}
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM   0
-		STYLE
-			COLOR         "#DCEACF"
-			OUTLINECOLOR  "#DCEACF"
-			WIDTH         0.5
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-	END
-	CLASS
-		EXPRESSION      /^(oever|kwelder).*$/
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM   0
-		STYLE
-			COLOR         "#F9F9E7"
-			OUTLINECOLOR  "#F9F9E7"
-			WIDTH         0.1
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-	END
-	CLASS
-		EXPRESSION      {open verharding,gesloten verharding,transitie,half verhard,perron,strekdam}
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM   0
-		STYLE
-			COLOR         "#FFFFFF"
-			OUTLINECOLOR  "#FFFFFF"
-			WIDTH         0.5
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-	END
-	CLASS
-		EXPRESSION      {loofbos,gemengd bos,bouwland,moeras,fruitteelt,boomteelt,naaldbos}
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM   0
-		STYLE
-			COLOR         "#CBE0B8"
-			OUTLINECOLOR  "#CBE0B8"
-			WIDTH         0.5
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-	END
-	CLASS
-		EXPRESSION      "heide"
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM   0
-		STYLE
-			COLOR         "#ddd6e5"
-			OUTLINECOLOR  "#ddd6e5"
-			WIDTH         0.1
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-	END
-END
+    LAYER
+        NAME                    begroeideterreindelen_vlak0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_fysiek_voorkomen, id from public.bgt_begroeideterreindelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        CLASSITEM               "bgt_fysiek_voorkomen"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "begroeideterreindelen_vlak0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            EXPRESSION          {rietland,duin,houtwal}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#F9F9E7"
+                OUTLINECOLOR    "#F9F9E7"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          {groenvoorziening,grasland overig,grasland agrarisch,struiken}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#DCEACF"
+                OUTLINECOLOR    "#DCEACF"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          "kwelder"
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#F9F9E7"
+                OUTLINECOLOR    "#F9F9E7"
+                WIDTH           0.1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          {loofbos,gemengd bos,bouwland,moeras,fruitteelt,boomteelt,naaldbos}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#CBE0B8"
+                OUTLINECOLOR    "#CBE0B8"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          "heide"
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#ddd6e5"
+                OUTLINECOLOR    "#ddd6e5"
+                WIDTH           0.1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
+
+    #-----------------------------------------------------------------------------
+    # Terreindeel 0 (onbegroeid)
+
+    LAYER
+        NAME                    onbegroeideterreindelen_vlak0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_fysiek_voorkomen, id from public.bgt_onbegroeideterreindelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        CLASSITEM               "bgt_fysiek_voorkomen"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "onbegroeideterreindelen_vlak0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            EXPRESSION          {erf,onverhard,zand}
+            STYLE
+                MAXSCALEDENOM   5000
+                MINSCALEDENOM   2500
+                COLOR           "#F9F9E7"
+                OUTLINECOLOR    "#F9F9E7"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+            STYLE
+                MAXSCALEDENOM   2500
+                MINSCALEDENOM   0
+                COLOR           "#F9F9E7"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          {open verharding,gesloten verharding,transitie,half verhard}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#FFFFFF"
+                OUTLINECOLOR    "#FFFFFF"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
 
   #-----------------------------------------------------------------------------
   # Overbrugging 0
 
-	LAYER
-		NAME                    spoorbaan_overbrugging
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "spoorbaan_overbrugging"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM		0
-			STYLE
-				COLOR         "#FFFFFF"
-				OUTLINECOLOR  "#FFFFFF"
-			END
-		END
-	END
+    LAYER
+        NAME                    overbruggingsdelen_vlak0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, id from public.bgt_overbruggingsdelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "overbruggingsdelen_vlak0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#FFFFFF"
+                OUTLINECOLOR    "#FFFFFF"
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Berm achter 0
 
-	LAYER
-		NAME                    ondersteunendewegdelen_achter_0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_ondersteunendewegdelen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM           0
-		CLASSITEM				"bgt_fysiek_voorkomen"
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "ondersteunendewegdelen_achter_0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			EXPRESSION      {open verharding,gesloten verharding,transitie,half verhard}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM    0
-			STYLE
-				COLOR         "#C9C7C2"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION     {groenvoorziening,onverhard}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM    0
-			STYLE
-				COLOR         "#C9C7C2"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    berm_achter_0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, id from public.bgt_ondersteunendewegdelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "berm_achter_0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Berm voor 0
 
-	LAYER
-		NAME                    ondersteunendewegdelen_voor_0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_ondersteunendewegdelen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM           0
-		CLASSITEM				"bgt_fysiek_voorkomen"
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "ondersteunendewegdelen_voor_0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			EXPRESSION      {open verharding,gesloten verharding,transitie,half verhard}
-			MAXSCALEDENOM   		3500
-			MINSCALEDENOM           0
-			STYLE
-				COLOR         "#F6F3F4"
-			END
-		END
-		CLASS
-			EXPRESSION     	{groenvoorziening,onverhard}
-			MAXSCALEDENOM   		3500
-			MINSCALEDENOM           0
-			STYLE
-				COLOR         "#DCEACF"
-			END
-		END
-	END
+    LAYER
+        NAME                    berm_voor_0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_fysiek_voorkomen, id from public.bgt_ondersteunendewegdelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        CLASSITEM               "bgt_fysiek_voorkomen"
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "berm_voor_0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            EXPRESSION          {open verharding,gesloten verharding,transitie,half verhard}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#F6F3F4"
+            END
+        END
+        CLASS
+            EXPRESSION          {groenvoorziening,onverhard}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#DCEACF"
+                OUTLINECOLOR    "#DCEACF"
+                WIDTH           1
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Rijbanen achter 0
 
-	LAYER
-			NAME                    rijbanen_achter_0
-			GROUP                   hoogte0
-			INCLUDE                 "connection/dataservices.inc"
-			DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-			TYPE                    POLYGON
-			CLASSITEM               "bgt_functie"
-			FILTER 					((((("[bgt_functie]" = "fietspad") Or (("[bgt_functie]" = "inrit") Or (("[bgt_functie]" = "OV-baan") Or (("[bgt_functie]" = "overweg") Or (("[bgt_functie]" = "rijbaan autoweg") Or (("[bgt_functie]" = "rijbaan lokale weg") Or (("[bgt_functie]" = "rijbaan regionale weg") Or (("[bgt_functie]" = "transitie") Or (("[bgt_functie]" = "baan voor vliegverkeer") Or ("[bgt_functie]" = "parkeervlak")))))))))))))
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			0
-			PROJECTION
-				"init=epsg:28992"
-			END
-			METADATA
-				"wms_title"            "rijbanen_achter_0"
-				"wms_group_title"      "hoogte0"
-			END
-			CLASS
-				EXPRESSION      {parkeervlak,rijbaan lokale weg,fietspad,inrit,transitie,rijbaan autoweg,rijbaan regionale weg,OV-baan,overweg,baan voor vliegverkeer}
-				MAXSCALEDENOM   3500
-				MINSCALEDENOM			0
-				STYLE
-					COLOR         "#C9C7C2"
-					OUTLINECOLOR  "#C9C7C2"
-					WIDTH         1
-					LINECAP       BUTT
-					LINEJOIN      MITER
-				END
-			END
-		END
+    LAYER
+        NAME                    rijbanen_achter_0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "fietspad,inrit,OV-baan,overweg,rijbaan autoweg,rijbaan lokale weg,rijbaan regionale weg,transitie,baan voor vliegverkeer,parkeervlak")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+            PROJECTION
+                "init=epsg:28992"
+            END
+            METADATA
+            "wms_title"         "rijbanen_achter_0"
+            "wms_group_title"   "hoogte0"
+            END
+            CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+                STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1.8
+                LINECAP         BUTT
+                LINEJOIN        MITER
+                END
+            END
+        END
 
   #-----------------------------------------------------------------------------
   # Rijbanen voor 0
 
-	LAYER
-		NAME                    rijbanen_voor_0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_functie"
-		FILTER 					((((("[bgt_functie]" = "fietspad") Or (("[bgt_functie]" = "inrit") Or (("[bgt_functie]" = "OV-baan") Or (("[bgt_functie]" = "overweg") Or (("[bgt_functie]" = "rijbaan autoweg") Or (("[bgt_functie]" = "rijbaan lokale weg") Or (("[bgt_functie]" = "rijbaan regionale weg") Or (("[bgt_functie]" = "transitie") Or (("[bgt_functie]" = "baan voor vliegverkeer") Or ("[bgt_functie]" = "parkeervlak")))))))))))))
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "rijbanen_voor_0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			EXPRESSION      {parkeervlak,rijbaan lokale weg,fietspad,inrit,transitie,rijbaan autoweg,rijbaan regionale weg,OV-baan,overweg,baan voor vliegverkeer}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#FFFFFF"
-			END
-		END
-		CLASS
-			EXPRESSION      "baan voor vliegverkeer"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#D3D2CF"
-			END
-		END
-	END
-
-  #-----------------------------------------------------------------------------
-  # Parkeervlakken 0
-
-  LAYER
-	NAME                    parkeervlak0
-	GROUP                   hoogte0
-	INCLUDE                 "connection/dataservices.inc"
-	DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '0' and eind_registratie isnull and bgt_functie = 'parkeervlak') As subquery USING srid=28992 USING UNIQUE id"
-	TYPE                    POLYGON
-	MAXSCALEDENOM           3500
-	MINSCALEDENOM			0
-	PROJECTION
-		"init=epsg:28992"
-	END
-	METADATA
-		"wms_title"            "parkeervlak0"
-		"wms_group_title"      "hoogte0"
-	END
-	CLASS
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM			0
-		STYLE
-			COLOR         "#C9C7C2"
-			OUTLINECOLOR  "#C9C7C2"
-			WIDTH         1
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-		STYLE
-			COLOR         "#FFFFFF"
-		END
-	END
-END
+    LAYER
+        NAME                    rijbanen_voor_0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "fietspad,inrit,OV-baan,overweg,rijbaan autoweg,rijbaan lokale weg,rijbaan regionale weg,transitie,baan voor vliegverkeer,parkeervlak")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "rijbanen_voor_0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#FFFFFF"
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Voetgangers achter 0
 
-	LAYER
-		NAME                    voetganers_achter_0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_functie"
-		FILTER ((((("[bgt_functie]" = "ruiterpad") Or (("[bgt_functie]" = "voetpad") Or (("[bgt_functie]" = "voetgangersgebied") Or (("[bgt_functie]" = "voetpad op trap") Or (("[bgt_functie]" = "woonerf") Or ("[bgt_functie]" = "verkeerseiland")))))))))
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "voetganers_achter_0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			EXPRESSION      {voetpad,verkeerseiland,voetpad op trap,voetgangersgebied,woonerf,ruiterpad}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#C9C7C2"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    voetganers_achter_0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "ruiterpad,voetpad,voetgangersgebied,voetpad op trap,woonerf")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "voetganers_achter_0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Voetgangers voor 0
 
-	LAYER
-		NAME                    voetgangers_voor_0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_functie"
-		FILTER ((((("[bgt_functie]" = "ruiterpad") Or (("[bgt_functie]" = "voetpad") Or (("[bgt_functie]" = "voetgangersgebied") Or (("[bgt_functie]" = "voetpad op trap") Or (("[bgt_functie]" = "woonerf") Or ("[bgt_functie]" = "verkeerseiland")))))))))
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "voetgangers_voor_0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			EXPRESSION      {voetpad,verkeerseiland,voetpad op trap,voetgangersgebied,woonerf,ruiterpad}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#f7f3f5"
-			END
-		END
-	END
-  #-----------------------------------------------------------------------------
-  # Inrichtingselement vlak 0
-  #Davey: 'muur' zit niet in deze nieuwe tabel? Moet die dan toch ergens andres vandaag komen? Perron lijkt ook hierin te zitten maar die zat nog bij terreindeel? Idk...
-
-	LAYER
-		NAME                    inrichtingselement_vlak0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_kunstwerkdelen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_type"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		FILTER (((("[bgt_type]" = "steiger") OR (("[bgt_type]" = "sluis") Or (("[bgt_type]" = "gemaal") Or ("[bgt_type]" = "stuw"))) OR ("[bgt_type]" = "muur"))))
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "inrichtingselement_vlak0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			EXPRESSION           "muur"
-			MAXSCALEDENOM 3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION           {sluis,gemaal,stuw}
-			MAXSCALEDENOM 3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR  "#C9C7C2"
-			END
-		END
-		CLASS
-			EXPRESSION           "steiger"
-			MAXSCALEDENOM 3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR             "#F2F1EE"
-				OUTLINECOLOR      "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM 3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR             "#FFFFFF"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    voetgangers_voor_0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "ruiterpad,voetpad,voetgangersgebied,voetpad op trap,woonerf")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "voetgangers_voor_0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#f7f3f5"
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
-  # Overigebouwerken (is nieuw bestond nog niet, 'bestaand' was hier los, die is nu richting 'panden') 0
+  # Kunstwerkdeel vlak 0
 
-	LAYER
-		NAME                    overigebouwerken_vlak0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_overigebouwwerken where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_type"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "overigebouwerken_vlak0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			EXPRESSION      "bestaand"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      {niet-bgt,transitie,lage trafo,open loods,opslagtank,bassin,windturbine,bezinkbak}
-			STYLE
-				MAXSCALEDENOM   3500
-				MINSCALEDENOM	0
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      "overkapping"
-			MAXSCALEDENOM   3500
-			STYLE
-				OPACITY       50
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
-
-	#-----------------------------------------------------------------------------
-	# Gebouwinstallaties (hierin vallen luivels, trappen etc)
-
-	LAYER
-		NAME                    gebouwinstallaties0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_gebouwinstallaties where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "gebouwinstallaties0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		
-	END
+    LAYER
+        NAME                    inrichtingselement_vlak0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_type, id from public.bgt_kunstwerkdelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_type]" ne "niet-bgt")
+        CLASSITEM               "bgt_type"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "inrichtingselement_vlak0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            EXPRESSION          {hoogspanningsmast,sluis,gemaal,stuw}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#C9C7C2"
+            END
+        END
+        CLASS
+            EXPRESSION          {perron,strekdam}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#f7f3f5"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          "steiger"
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM        0
+            STYLE
+                COLOR           "#F2F1EE"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
-	  # Panden (dit was een onderdeel van 'gebouw') (moet even 'PANDEN' worden.)
+    # Scheiding vlak 0
 
-	  LAYER
-		NAME                    panden_vlak0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_panden where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_status"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "panden_vlak0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			EXPRESSION      "bestaand"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		
-	END
+    LAYER
+        NAME                    scheiding_vlak0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_type, id from public.bgt_scheidingen where relatieve_hoogteligging = 0 and geometrie_vlak IS NOT NULL and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_type]" = "muur")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "scheiding_vlak0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#E0DED8"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
+
+    #-----------------------------------------------------------------------------
+    # Gebouw 0
+
+    LAYER
+        NAME                    gebouw_vlak0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_type, id from public.bgt_overigebouwwerken where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        CLASSITEM               "bgt_type"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "gebouw_vlak0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            EXPRESSION          {niet-bgt,transitie,lage trafo,open loods,opslagtank,windturbine}
+            STYLE
+                MAXSCALEDENOM   5000
+                MINSCALEDENOM   0
+                COLOR           "#E0DED8"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          {bassin,bezinkbak}
+            STYLE
+                MAXSCALEDENOM   5000
+                MINSCALEDENOM   0
+                COLOR           "#95C6D5"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           2
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          "overkapping"
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                OPACITY         50
+                COLOR           "#E0DED8"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
+
+  #-----------------------------------------------------------------------------
+    # Panden 0
+
+      LAYER
+        NAME                    panden_vlak0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, id from public.bgt_panden where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "panden_vlak0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#E5E3DE"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.9
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Metro achter 0
 
-	LAYER
-		NAME                    metro_achter0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM              "bgt_functie"
-		FILTER					"sneltram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_achter0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-				MAXSCALEDENOM           3500
-				MINSCALEDENOM			2000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-				MAXSCALEDENOM           2000
-				MINSCALEDENOM			0
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    metro_achter0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "sneltram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "metro_achter0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           3
+                OUTLINECOLOR    "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           3.5
+                OUTLINECOLOR    "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Metro voor 0
 
-	LAYER
-		NAME                    metro_voor0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM              "bgt_functie"
-		FILTER					"sneltram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_voor0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			2000
-			STYLE
-
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-		MAXSCALEDENOM           2000
-		MINSCALEDENOM		0
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    metro_voor0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "sneltram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "metro_voor0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           2
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           2.5
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Tram 0
 
-	LAYER
-		NAME                    tram0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM              "bgt_functie"
-		FILTER					"tram"
-		MAXSCALEDENOM           3500
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "tram0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			2000
-			STYLE
-
-				WIDTH         1.5
-				COLOR         "#FC7F7F"
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM           2000
-			MINSCALEDENOM			0
-			STYLE
-
-				WIDTH         2
-				COLOR         "#FC7F7F"
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    tram0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "tram"
+        MAXSCALEDENOM           5000
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "tram0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           1.5
+                COLOR           "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           2
+                COLOR           "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Trein achter 0
 
-	LAYER
-		NAME                    trein_achter0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM              "bgt_functie"
-		FILTER					"trein"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_achter0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			2000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM           2000
-			MINSCALEDENOM			0
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    trein_achter0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "trein"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "trein_achter0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           3
+                OUTLINECOLOR    "#9D9D9D"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           3.5
+                OUTLINECOLOR    "#9D9D9D"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Trein voor 0
 
-	LAYER
-		NAME                    trein_voor0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM              "bgt_functie"
-		FILTER					"trein"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_voor0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			2000
-			STYLE
-
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-		MAXSCALEDENOM           2000
-				MINSCALEDENOM			0
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    trein_voor0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "trein"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "trein_voor0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           2500
+            STYLE
+                WIDTH           2
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    8
+                    8
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           2.5
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    8
+                    8
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Snelweg achter 0
 
-	LAYER
-		NAME                    snelweg_achter_0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		FILTERITEM              "bgt_functie"
-		FILTER					"rijbaan autosnelweg"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "snelweg_achter_0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			0
-			STYLE
-			COLOR         "#C9C7C2"
-			OUTLINECOLOR  "#C9C7C2"
-			WIDTH         1
-			LINECAP       BUTT
-			LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    snelweg_achter_0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTERITEM              "bgt_functie"
+        FILTER                  "rijbaan autosnelweg"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "snelweg_achter_0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Snelweg voor 0
 
-	LAYER
-		NAME                    snelweg_voor_0
-		GROUP                   hoogte0
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		FILTERITEM              "bgt_functie"
-		FILTER					"rijbaan autosnelweg"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "snelweg_voor_0"
-			"wms_group_title"      "hoogte0"
-		END
-		CLASS
-		  MAXSCALEDENOM 3500
-		  MINSCALEDENOM			0
-		  STYLE
-			COLOR         "#FEFAFA"
-		  END
-		END
-	END
+    LAYER
+        NAME                    snelweg_voor_0
+        GROUP                   hoogte0
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTERITEM              "bgt_functie"
+        FILTER                  "rijbaan autosnelweg"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "snelweg_voor_0"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+          MAXSCALEDENOM         5000
+          MINSCALEDENOM         0
+          STYLE
+            COLOR               "#FEFAFA"
+          END
+        END
+    END
 
   #-----------------------------------------------------------------------------
 
    LAYER
-     NAME            "ligplaats"
-     GROUP           "hoogte0"
-     INCLUDE         "connection/dataservices.inc"
-	 DATA			  "geometrie FROM (select * from public.bag_ligplaatsen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-     TYPE            POLYGON
-     MAXSCALEDENOM   3500
-     PROJECTION
-     "init=epsg:28992"
+        NAME                    "ligplaats"
+        GROUP                   "hoogte0"
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie, identificatie from public.bag_ligplaatsen where eind_geldigheid isnull) As subquery USING srid=28992 USING UNIQUE identificatie"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "ligplaats"
+            "wms_group_title"   "hoogte0"
      END
-
-     METADATA
-       "wms_title"           "ligplaats"
-       "wms_group_title"     "hoogte0"
-     END
-
      CLASS
        STYLE
-         ANTIALIAS      true
-         COLOR         "#E5E3DE"
-         OUTLINECOLOR  "#C9C7C2"
-         WIDTH          1
-         OPACITY        60
+                ANTIALIAS       true
+                COLOR           "#E5E3DE"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1
+                OPACITY         60
        END
      END
-
    END
 
    #-----------------------------------------------------------------------------
 
-   LAYER
-     NAME            "standplaats"
-     GROUP           "hoogte0"
-     INCLUDE         "connection/dataservices.inc"
-	 DATA            "geometrie FROM (select * from public.bag_standplaatsen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-     TYPE            POLYGON
-     MAXSCALEDENOM   3500
-     PROJECTION
-     "init=epsg:28992"
-     END
-
-     METADATA
-       "wms_title"           "standplaats"
-       "wms_group_title"     "hoogte0"
-     END
-
-     CLASS
-       STYLE
-         ANTIALIAS      true
-         COLOR         "#E5E3DE"
-         OUTLINECOLOR  "#C9C7C2"
-         WIDTH          1
-         OPACITY        60
+    LAYER
+        NAME                    "standplaats"
+        GROUP                   "hoogte0"
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie, identificatie from public.bag_standplaatsen where eind_geldigheid isnull) As subquery USING srid=28992 USING UNIQUE identificatie"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+           "wms_title"          "standplaats"
+            "wms_group_title"   "hoogte0"
+        END
+        CLASS
+            STYLE
+            ANTIALIAS       true
+            COLOR           "#E5E3DE"
+            OUTLINECOLOR    "#C9C7C2"
+            WIDTH           1
+            OPACITY         60
        END
      END
-
   END
-
-
-
-
 
 #==============================================================================
 ## HOOGTELIGGING 1
@@ -1098,971 +959,841 @@ END
 
 # Tunnel -1 (relatieve hoogteligging -1?)
 
-	LAYER
-		NAME                    wegdeel_vlak_tunnel1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '0' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_functie"
-		FILTER ((((("[bgt_functie]" = "rijbaan autoweg") Or (("[bgt_functie]" = "rijbaan lokale weg") Or ("[bgt_functie]" = "rijbaan regionale weg"))))))
-		MAXSCALEDENOM           3500
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "wegdeel_vlak_tunnel1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			EXPRESSION      {rijbaan autoweg,rijbaan regionale weg,rijbaan lokale weg}
-			MAXSCALEDENOM   3500
-			STYLE
-				OPACITY        30
-				COLOR         "#FFFFFF"
-			END
-		END
-	END
+    LAYER
+        NAME                    wegdeel_vlak_tunnel1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 0 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "wegdeel_vlak_tunnel1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            STYLE
+                OPACITY         30
+                COLOR           "#FFFFFF"
+            END
+        END
+    END
 
-  #-----------------------------------------------------------------------------
-  # Terreindeel 1
+    #-----------------------------------------------------------------------------
+    # Terreindeel 1 (begroeid)
 
-	LAYER
-		NAME                    begroeideterreindelen_vlak1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_begroeideterreindelen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_fysiek_voorkomen"
-		FILTER (("[bgt_fysiek_voorkomen]" = "erf") Or ("[bgt_fysiek_voorkomen]" = "zand") Or ("[bgt_fysiek_voorkomen]" = "onverhard") Or ("[bgt_fysiek_voorkomen]" = "houtwal") Or ("[bgt_fysiek_voorkomen]" = "kwelder") Or ("[bgt_fysiek_voorkomen]" = "heide") Or ("[bgt_fysiek_voorkomen]" = "strekdam") Or ("[bgt_fysiek_voorkomen]" = "rietland") Or ("[bgt_fysiek_voorkomen]" = "gesloten verharding") Or ("[bgt_fysiek_voorkomen]" = "half verhard" ) Or ("[bgt_fysiek_voorkomen]" = "perron") Or ("[bgt_fysiek_voorkomen]" = "transitie") Or ("[bgt_fysiek_voorkomen]" = "open verharding" ) Or ("[bgt_fysiek_voorkomen]" = "groenvoorziening") Or ("[bgt_fysiek_voorkomen]" = "struiken") Or ("[bgt_fysiek_voorkomen]" = "grasland overig" ) Or ("[bgt_fysiek_voorkomen]" = "grasland agrarisch" ) Or ("[bgt_fysiek_voorkomen]" = "naaldbos") Or ("[bgt_fysiek_voorkomen]" = "fruitteelt") Or ("[bgt_fysiek_voorkomen]" = "loofbos") Or ("[bgt_fysiek_voorkomen]" = "bouwland") Or ("[bgt_fysiek_voorkomen]" = "gemengd bos" ) Or ("[bgt_fysiek_voorkomen]" = "moeras") Or ("[bgt_fysiek_voorkomen]" = "boomteelt") Or ("[bgt_fysiek_voorkomen]" = "oever, slootkant") )
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "begroeidterreindeel_vlak1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			EXPRESSION      {erf,onverhard,rietland,zand,houtwal}
-			STYLE
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   2000
-				COLOR         "#F9F9E7"
-				OUTLINECOLOR  "#F9F9E7"
-			END
-			STYLE
-			MAXSCALEDENOM   2000
-			MINSCALEDENOM   0
-				COLOR         "#F9F9E7"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      {groenvoorziening,grasland overig,grasland agrarisch,struiken}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#DCEACF"
-				OUTLINECOLOR  "#DCEACF"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      /^(oever|kwelder).*$/
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#F9F9E7"
-				OUTLINECOLOR  "#F9F9E7"
-				WIDTH         0.1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      {open verharding,gesloten verharding,transitie,half verhard,perron,strekdam}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#FFFFFF"
-				OUTLINECOLOR  "#FFFFFF"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      {loofbos,gemengd bos,bouwland,moeras,fruitteelt,boomteelt,naaldbos}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#CBE0B8"
-				OUTLINECOLOR  "#CBE0B8"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      "heide"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#ddd6e5"
-				OUTLINECOLOR  "#ddd6e5"
-				WIDTH         0.1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    begroeideterreindelen_vlak1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_fysiek_voorkomen, id from public.bgt_begroeideterreindelen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        CLASSITEM               "bgt_fysiek_voorkomen"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "begroeideterreindelen_vlak1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            EXPRESSION          {rietland,duin,houtwal}
+            STYLE
+                MAXSCALEDENOM   5000
+            MINSCALEDENOM   0
+                COLOR           "#F9F9E7"
+                OUTLINECOLOR    "#F9F9E7"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          {groenvoorziening,grasland overig,grasland agrarisch,struiken}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#DCEACF"
+                OUTLINECOLOR    "#DCEACF"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          "kwelder"
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#F9F9E7"
+                OUTLINECOLOR    "#F9F9E7"
+                WIDTH           0.1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          {loofbos,gemengd bos,bouwland,moeras,fruitteelt,boomteelt,naaldbos}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#CBE0B8"
+                OUTLINECOLOR    "#CBE0B8"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          "heide"
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#ddd6e5"
+                OUTLINECOLOR    "#ddd6e5"
+                WIDTH           0.1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
-	 #-----------------------------------------------------------------------------
+    #-----------------------------------------------------------------------------
+    # Terreindeel 1 (onbegroeid)
 
-  LAYER
-	NAME                    onbegroeideterreindelen_vlak1
-	GROUP                   hoogte1
-	INCLUDE                 "connection/dataservices.inc"
-	DATA                    "geometrie FROM (select * from public.bgt_onbegroeideterreindelen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-	TYPE                    POLYGON
-	CLASSITEM               "bgt_fysiek_voorkomen"
-	FILTER (("[bgt_fysiek_voorkomen]" = "erf") Or ("[bgt_fysiek_voorkomen]" = "zand") Or ("[bgt_fysiek_voorkomen]" = "onverhard") Or ("[bgt_fysiek_voorkomen]" = "houtwal") Or ("[bgt_fysiek_voorkomen]" = "kwelder") Or ("[bgt_fysiek_voorkomen]" = "heide") Or ("[bgt_fysiek_voorkomen]" = "strekdam") Or ("[bgt_fysiek_voorkomen]" = "rietland") Or ("[bgt_fysiek_voorkomen]" = "gesloten verharding") Or ("[bgt_fysiek_voorkomen]" = "half verhard" ) Or ("[bgt_fysiek_voorkomen]" = "perron") Or ("[bgt_fysiek_voorkomen]" = "transitie") Or ("[bgt_fysiek_voorkomen]" = "open verharding" ) Or ("[bgt_fysiek_voorkomen]" = "groenvoorziening") Or ("[bgt_fysiek_voorkomen]" = "struiken") Or ("[bgt_fysiek_voorkomen]" = "grasland overig" ) Or ("[bgt_fysiek_voorkomen]" = "grasland agrarisch" ) Or ("[bgt_fysiek_voorkomen]" = "naaldbos") Or ("[bgt_fysiek_voorkomen]" = "fruitteelt") Or ("[bgt_fysiek_voorkomen]" = "loofbos") Or ("[bgt_fysiek_voorkomen]" = "bouwland") Or ("[bgt_fysiek_voorkomen]" = "gemengd bos" ) Or ("[bgt_fysiek_voorkomen]" = "moeras") Or ("[bgt_fysiek_voorkomen]" = "boomteelt") Or ("[bgt_fysiek_voorkomen]" = "oever, slootkant") )
-	MAXSCALEDENOM           3500
-	MINSCALEDENOM			0
-	PROJECTION
-		"init=epsg:28992"
-	END
-	METADATA
-		"wms_title"            "onbegroeidterreindeel_vlak1"
-		"wms_group_title"      "hoogte1"
-	END
-	CLASS
-		EXPRESSION      {erf,onverhard,rietland,zand,houtwal}
-		STYLE
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM   2000
-			COLOR         "#F9F9E7"
-			OUTLINECOLOR  "#F9F9E7"
-		END
-		STYLE
-		MAXSCALEDENOM   2000
-		MINSCALEDENOM   0
-			COLOR         "#F9F9E7"
-			OUTLINECOLOR  "#C9C7C2"
-			WIDTH         0.5
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-	END
-	CLASS
-		EXPRESSION      {groenvoorziening,grasland overig,grasland agrarisch,struiken}
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM   0
-		STYLE
-			COLOR         "#DCEACF"
-			OUTLINECOLOR  "#DCEACF"
-			WIDTH         0.5
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-	END
-	CLASS
-		EXPRESSION      /^(oever|kwelder).*$/
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM   0
-		STYLE
-			COLOR         "#F9F9E7"
-			OUTLINECOLOR  "#F9F9E7"
-			WIDTH         0.1
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-	END
-	CLASS
-		EXPRESSION      {open verharding,gesloten verharding,transitie,half verhard,perron,strekdam}
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM   0
-		STYLE
-			COLOR         "#FFFFFF"
-			OUTLINECOLOR  "#FFFFFF"
-			WIDTH         0.5
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-	END
-	CLASS
-		EXPRESSION      {loofbos,gemengd bos,bouwland,moeras,fruitteelt,boomteelt,naaldbos}
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM   0
-		STYLE
-			COLOR         "#CBE0B8"
-			OUTLINECOLOR  "#CBE0B8"
-			WIDTH         0.5
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-	END
-	CLASS
-		EXPRESSION      "heide"
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM   0
-		STYLE
-			COLOR         "#ddd6e5"
-			OUTLINECOLOR  "#ddd6e5"
-			WIDTH         0.1
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-	END
-END
+    LAYER
+        NAME                    onbegroeideterreindelen_vlak1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_fysiek_voorkomen, id from public.bgt_onbegroeideterreindelen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        CLASSITEM               "bgt_fysiek_voorkomen"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "onbegroeideterreindelen_vlak1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            EXPRESSION          {erf,onverhard,zand}
+        STYLE
+                MAXSCALEDENOM   5000
+                MINSCALEDENOM   2500
+                COLOR           "#F9F9E7"
+                OUTLINECOLOR    "#F9F9E7"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+        END
+        STYLE
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+                COLOR           "#F9F9E7"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+        END
+    END
+    CLASS
+            EXPRESSION          {open verharding,gesloten verharding,transitie,half verhard}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#FFFFFF"
+                OUTLINECOLOR    "#FFFFFF"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
+
+    #-----------------------------------------------------------------------------
+    # Overbrugging 1
+
+    LAYER
+        NAME                    overbruggingsdelen_vlak1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, id from public.bgt_overbruggingsdelen where relatieve_hoogteligging = 1  and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "overbruggingsdelen_vlak1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#FFFFFF"
+                OUTLINECOLOR    "#FFFFFF"
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Berm achter 1
 
-	LAYER
-		NAME                    ondersteunendewegdelen_achter_1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_ondersteunendewegdelen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM           0
-		CLASSITEM				"bgt_fysiek_voorkomen"
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "ondersteunendewegdelen_achter_1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			EXPRESSION      {open verharding,gesloten verharding,transitie,half verhard}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM    0
-			STYLE
-				COLOR         "#C9C7C2"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION     {groenvoorziening,onverhard}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM    0
-			STYLE
-				COLOR         "#C9C7C2"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    berm_achter_1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, id from public.bgt_ondersteunendewegdelen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "berm_achter_1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Berm voor 1
 
-	LAYER
-		NAME                    ondersteunendewegdelen_voor_1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_ondersteunendewegdelen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM           0
-		CLASSITEM				"bgt_fysiek_voorkomen"
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "ondersteunendewegdelen_voor_1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			EXPRESSION      {open verharding,gesloten verharding,transitie,half verhard}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM    0
-			STYLE
-				COLOR         "#F6F3F4"
-			END
-		END
-		CLASS
-			EXPRESSION     {groenvoorziening,onverhard}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM    0
-			STYLE
-				COLOR         "#DCEACF"
-			END
-		END
-	END
+    LAYER
+        NAME                    berm_voor_1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_fysiek_voorkomen, id from public.bgt_ondersteunendewegdelen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        CLASSITEM                "bgt_fysiek_voorkomen"
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "berm_voor_1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            EXPRESSION          {open verharding,gesloten verharding,transitie,half verhard}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#F6F3F4"
+            END
+        END
+        CLASS
+            EXPRESSION          {groenvoorziening,onverhard}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#DCEACF"
+                OUTLINECOLOR    "#DCEACF"
+                WIDTH           1
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Rijbanen achter 1
 
-	LAYER
-		NAME                    rijbanen_achter_1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_functie"
-		FILTER 					((((("[bgt_functie]" = "fietspad") Or (("[bgt_functie]" = "inrit") Or (("[bgt_functie]" = "OV-baan") Or (("[bgt_functie]" = "overweg") Or (("[bgt_functie]" = "rijbaan autoweg") Or (("[bgt_functie]" = "rijbaan lokale weg") Or (("[bgt_functie]" = "rijbaan regionale weg") Or (("[bgt_functie]" = "transitie") Or (("[bgt_functie]" = "baan voor vliegverkeer") Or ("[bgt_functie]" = "parkeervlak")))))))))))))
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "rijbanen_achter_1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			EXPRESSION      {parkeervlak,rijbaan lokale weg,fietspad,inrit,transitie,rijbaan autoweg,rijbaan regionale weg,OV-baan,overweg,baan voor vliegverkeer}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#C9C7C2"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         1.8
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    rijbanen_achter_1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "fietspad,inrit,OV-baan,overweg,rijbaan autoweg,rijbaan lokale weg,rijbaan regionale weg,transitie,baan voor vliegverkeer,parkeervlak")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "rijbanen_achter_1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1.8
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
   #-----------------------------------------------------------------------------
   # Rijbanen voor 1
 
-	LAYER
-		NAME                    rijbanen_voor_1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_functie"
-		FILTER 					((((("[bgt_functie]" = "fietspad") Or (("[bgt_functie]" = "inrit") Or (("[bgt_functie]" = "OV-baan") Or (("[bgt_functie]" = "overweg") Or (("[bgt_functie]" = "rijbaan autoweg") Or (("[bgt_functie]" = "rijbaan lokale weg") Or (("[bgt_functie]" = "rijbaan regionale weg") Or (("[bgt_functie]" = "transitie") Or (("[bgt_functie]" = "baan voor vliegverkeer") Or ("[bgt_functie]" = "parkeervlak")))))))))))))
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "rijbanen_voor_1"
-			"wms_group_title"      "hoogte1"
-		END
-		 CLASS
-			EXPRESSION      {parkeervlak,rijbaan lokale weg,fietspad,inrit,transitie,rijbaan autoweg,rijbaan regionale weg,OV-baan,overweg,baan voor vliegverkeer}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#FFFFFF"
-			END
-		END
-		CLASS
-			EXPRESSION      "baan voor vliegverkeer"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#D3D2CF"
-			END
-		END
-	END
-
- #-----------------------------------------------------------------------------
-  # Parkeervlakken 1
-
-  LAYER
-	NAME                    parkeervlak1
-	GROUP                   hoogte1
-	INCLUDE                 "connection/dataservices.inc"
-	DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '1' and eind_registratie isnull and bgt_functie = 'parkeervlak') As subquery USING srid=28992 USING UNIQUE id"
-	TYPE                    POLYGON
-	MAXSCALEDENOM           3500
-	MINSCALEDENOM			0
-	PROJECTION
-		"init=epsg:28992"
-	END
-	METADATA
-		"wms_title"            "parkeervlak1"
-		"wms_group_title"      "hoogte1"
-	END
-	CLASS
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM			0
-		STYLE
-			COLOR         "#C9C7C2"
-			OUTLINECOLOR  "#C9C7C2"
-			WIDTH         1
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-		STYLE
-			COLOR         "#FFFFFF"
-		END
-	END
-END
+    LAYER
+        NAME                    rijbanen_voor_1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "fietspad,inrit,OV-baan,overweg,rijbaan autoweg,rijbaan lokale weg,rijbaan regionale weg,transitie,baan voor vliegverkeer,parkeervlak")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "rijbanen_voor_1"
+            "wms_group_title"   "hoogte1"
+        END
+         CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#FFFFFF"
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Voetgangers achter 1
 
-	LAYER
-		NAME                    voetganers_achter_1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_functie"
-		FILTER ((((("[bgt_functie]" = "ruiterpad") Or (("[bgt_functie]" = "voetpad") Or (("[bgt_functie]" = "voetgangersgebied") Or (("[bgt_functie]" = "voetpad op trap") Or (("[bgt_functie]" = "woonerf") Or ("[bgt_functie]" = "verkeerseiland")))))))))
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "voetganers_achter_1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			EXPRESSION      {voetpad,verkeerseiland,voetpad op trap,voetgangersgebied,woonerf,ruiterpad}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#C9C7C2"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    voetganers_achter_1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "ruiterpad,voetpad,voetgangersgebied,voetpad op trap,woonerf")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "voetganers_achter_1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
+    
   #-----------------------------------------------------------------------------
   # Voetgangers voor 1
 
-	LAYER
-		NAME                    voetgangers_voor_1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_functie"
-		FILTER ((((("[bgt_functie]" = "ruiterpad") Or (("[bgt_functie]" = "voetpad") Or (("[bgt_functie]" = "voetgangersgebied") Or (("[bgt_functie]" = "voetpad op trap") Or (("[bgt_functie]" = "woonerf") Or ("[bgt_functie]" = "verkeerseiland")))))))))
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "voetgangers_voor_1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			EXPRESSION      {voetpad,verkeerseiland,voetpad op trap,voetgangersgebied,woonerf,ruiterpad}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#f7f3f5"
-			END
-		END
-	END
+    LAYER
+        NAME                    voetgangers_voor_1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "ruiterpad,voetpad,voetgangersgebied,voetpad op trap,woonerf")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "voetgangers_voor_1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#f7f3f5"
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
-  # Gebouw 1
+    # Kunstwerkdeel vlak 1
 
-	LAYER
-		NAME                    gebouw_vlak1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_overigebouwwerken where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_type"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "gebouw_vlak1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			EXPRESSION      "overkapping"
-			MAXSCALEDENOM   3500
-			STYLE
-				OPACITY       50
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      {niet-bgt,transitie,lage trafo,open loods,opslagtank,bassin,windturbine,bezinkbak}
-			STYLE
-				MAXSCALEDENOM   3500
-				MINSCALEDENOM	0
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      "bestaand"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    inrichtingselement_vlak1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_type, id from public.bgt_kunstwerkdelen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_type]" ne "niet-bgt")
+        CLASSITEM               "bgt_type"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM            0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "inrichtingselement_vlak1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            EXPRESSION          {hoogspanningsmast,sluis,gemaal,stuw}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM        0
+            STYLE
+                COLOR           "#C9C7C2"
+            END
+        END
+        CLASS
+            EXPRESSION          {perron,strekdam}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#f7f3f5"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          "steiger"
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM        0
+            STYLE
+                COLOR           "#F2F1EE"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
-  # Inrichtingselement vlak 1
+    # Scheiding vlak 1
 
-	LAYER
-		NAME                    inrichtingselement_vlak1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_kunstwerkdelen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_type"
-		FILTER (((("[bgt_type]" = "steiger") OR (("[bgt_type]" = "sluis") Or (("[bgt_type]" = "gemaal") Or ("[bgt_type]" = "stuw"))) OR ("[bgt_type]" = "muur"))))
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "inrichtingselement_vlak1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			EXPRESSION           "muur"
-			MAXSCALEDENOM 3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION           {sluis,gemaal,stuw}
-			MAXSCALEDENOM 3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR  "#C9C7C2"
-			END
-		END
-		CLASS
-			EXPRESSION           "steiger"
-			MAXSCALEDENOM 3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR             "#F2F1EE"
-				OUTLINECOLOR      "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM 3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR             "#FFFFFF"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    scheiding_vlak1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_type, id from public.bgt_kunstwerkdelen where geometrie_vlak IS NULL and relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_type]" = "muur")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "scheiding_vlak1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#E0DED8"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
-	#-----------------------------------------------------------------------------
-	# Gebouwinstallaties (hierin vallen luivels, trappen etc)
+    #-----------------------------------------------------------------------------
+    # Gebouw 1
 
-	LAYER
-		NAME                    gebouwinstallaties1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_gebouwinstallaties where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "gebouwinstallaties1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		
-	END
+    LAYER
+        NAME                    gebouw_vlak1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_type, id from public.bgt_overigebouwwerken where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        CLASSITEM               "bgt_type"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "gebouw_vlak1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            EXPRESSION          {niet-bgt,transitie,lage trafo,open loods,opslagtank,windturbine}
+            STYLE
+                MAXSCALEDENOM   5000
+                MINSCALEDENOM   0
+                COLOR           "#E0DED8"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          {bassin,bezinkbak}
+            STYLE
+                MAXSCALEDENOM   5000
+                MINSCALEDENOM   0
+                COLOR           "#95C6D5"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           2
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          "overkapping"
+            MAXSCALEDENOM       5000
+            STYLE
+                OPACITY         50
+                COLOR           "#E0DED8"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
-	#-----------------------------------------------------------------------------
-	  # Panden (dit was een onderdeel van 'gebouw') (nu hier los uit de bgt gehaald)
+    #-----------------------------------------------------------------------------
+    # Panden 1
 
-	LAYER
-		NAME                    panden_vlak1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_panden where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_status"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "panden_vlak1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			EXPRESSION      "bestaand"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		
-	END
+    LAYER
+        NAME                    panden_vlak1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, id from public.bgt_panden where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "panden_vlak1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#E5E3DE"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.9
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Metro achter 1
 
-	LAYER
-		NAME                    metro_achter1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM               "bgt_functie"
-		FILTER					"sneltram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_achter1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-				MAXSCALEDENOM           3500
-				MINSCALEDENOM			2000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-				MAXSCALEDENOM           2000
-				MINSCALEDENOM			0
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    metro_achter1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "sneltram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "metro_achter1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           3
+                OUTLINECOLOR    "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           3.5
+                OUTLINECOLOR    "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Metro voor 1
 
-	LAYER
-		NAME                    metro_voor1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM               "bgt_functie"
-		FILTER					"sneltram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_voor1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			2000
-			STYLE
-
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-		MAXSCALEDENOM           2000
-		MINSCALEDENOM		0
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    metro_voor1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "sneltram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "metro_voor1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           2
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           2.5
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Tram 1
 
-	LAYER
-		NAME                    tram1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM               "bgt_functie"
-		FILTER					"tram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "tram1"
-			"wms_group_title"      "hoogte1"
-		END
-			CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			2000
-			STYLE
-
-				WIDTH         1.5
-				COLOR         "#FC7F7F"
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM           2000
-			MINSCALEDENOM			0
-			STYLE
-
-				WIDTH         2
-				COLOR         "#FC7F7F"
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    tram1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "tram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "tram1"
+            "wms_group_title"   "hoogte1"
+        END
+            CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           1.5
+                COLOR           "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           2
+                COLOR           "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Trein achter 1
 
-	LAYER
-		NAME                    trein_achter1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM               "bgt_functie"
-		FILTER					"trein"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_achter1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			2000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM           2000
-			MINSCALEDENOM			0
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    trein_achter1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "trein"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "trein_achter1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           3
+                OUTLINECOLOR    "#9D9D9D"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           3.5
+                OUTLINECOLOR    "#9D9D9D"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Trein voor 1
 
-	LAYER
-		NAME                    trein_voor1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE					LINE
-		FILTERITEM               "bgt_functie"
-		FILTER					"trein"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_voor1"
-			"wms_group_title"      "hoogte1"
-		END
-			CLASS
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			2000
-			STYLE
-
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-		MAXSCALEDENOM           2000
-				MINSCALEDENOM			0
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    trein_voor1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "trein"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "trein_voor1"
+            "wms_group_title"   "hoogte1"
+        END
+            CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           2
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    8
+                    8
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           2.5
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    8
+                    8
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Snelweg achter 1
 
-	LAYER
-		NAME                    snelweg_achter1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		FILTERITEM              "bgt_functie"
-		FILTER					"rijbaan autosnelweg"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "snelweg_achter_1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			0
-			STYLE
-			COLOR         "#C9C7C2"
-			OUTLINECOLOR  "#C9C7C2"
-			WIDTH         1
-			LINECAP       BUTT
-			LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    snelweg_achter1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTERITEM              "bgt_functie"
+        FILTER                  "rijbaan autosnelweg"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "snelweg_achter_1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Snelweg voor 1
 
-	LAYER
-		NAME                    snelweg_voor1
-		GROUP                   hoogte1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE					LINE
-		FILTERITEM              "bgt_functie"
-		FILTER					"rijbaan autosnelweg"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "snelweg_voor_1"
-			"wms_group_title"      "hoogte1"
-		END
-		CLASS
-		 MAXSCALEDENOM           3500
-			MINSCALEDENOM			0
-		  STYLE
-			COLOR         "#FEFAFA"
-		  END
-		END
-	END
+    LAYER
+        NAME                    snelweg_voor1
+        GROUP                   hoogte1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 1 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTERITEM              "bgt_functie"
+        FILTER                  "rijbaan autosnelweg"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "snelweg_voor_1"
+            "wms_group_title"   "hoogte1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+          STYLE
+                COLOR           "#FEFAFA"
+          END
+        END
+    END
 
 
 
@@ -2070,1749 +1801,1603 @@ END
 ## HOOGTELIGGING 2
 #==============================================================================
 
+    # Terreindeel 2 (begroeid)
+
+    LAYER
+        NAME                    begroeideterreindelen_vlak2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_fysiek_voorkomen, id from public.bgt_begroeideterreindelen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        CLASSITEM               "bgt_fysiek_voorkomen"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "begroeideterreindelen_vlak2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            EXPRESSION          {rietland,duin,houtwal}
+            STYLE
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+                COLOR           "#F9F9E7"
+                OUTLINECOLOR    "#F9F9E7"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          {groenvoorziening,grasland overig,grasland agrarisch,struiken}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#DCEACF"
+                OUTLINECOLOR    "#DCEACF"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          "kwelder"
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#F9F9E7"
+                OUTLINECOLOR    "#F9F9E7"
+                WIDTH           0.1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          {loofbos,gemengd bos,bouwland,moeras,fruitteelt,boomteelt,naaldbos}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#CBE0B8"
+                OUTLINECOLOR    "#CBE0B8"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          "heide"
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#ddd6e5"
+                OUTLINECOLOR    "#ddd6e5"
+                WIDTH           0.1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
+
+    #-----------------------------------------------------------------------------
 # Terreindeel 2 (onbegroeid)
-	LAYER
-		NAME                    onbegroeideterreindelen_vlak2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_onbegroeideterreindelen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_fysiek_voorkomen"
-		FILTER (("[bgt_fysiek_voorkomen]" = "erf") Or ("[bgt_fysiek_voorkomen]" = "zand") Or ("[bgt_fysiek_voorkomen]" = "onverhard") Or ("[bgt_fysiek_voorkomen]" = "houtwal") Or ("[bgt_fysiek_voorkomen]" = "kwelder") Or ("[bgt_fysiek_voorkomen]" = "heide") Or ("[bgt_fysiek_voorkomen]" = "strekdam") Or ("[bgt_fysiek_voorkomen]" = "rietland") Or ("[bgt_fysiek_voorkomen]" = "gesloten verharding") Or ("[bgt_fysiek_voorkomen]" = "half verhard" ) Or ("[bgt_fysiek_voorkomen]" = "perron") Or ("[bgt_fysiek_voorkomen]" = "transitie") Or ("[bgt_fysiek_voorkomen]" = "open verharding" ) Or ("[bgt_fysiek_voorkomen]" = "groenvoorziening") Or ("[bgt_fysiek_voorkomen]" = "struiken") Or ("[bgt_fysiek_voorkomen]" = "grasland overig" ) Or ("[bgt_fysiek_voorkomen]" = "grasland agrarisch" ) Or ("[bgt_fysiek_voorkomen]" = "naaldbos") Or ("[bgt_fysiek_voorkomen]" = "fruitteelt") Or ("[bgt_fysiek_voorkomen]" = "loofbos") Or ("[bgt_fysiek_voorkomen]" = "bouwland") Or ("[bgt_fysiek_voorkomen]" = "gemengd bos" ) Or ("[bgt_fysiek_voorkomen]" = "moeras") Or ("[bgt_fysiek_voorkomen]" = "boomteelt") Or ("[bgt_fysiek_voorkomen]" = "oever, slootkant") )
-		#MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "onbegroeideterreindelen_vlak2"
-			"wms_group_title"      "hoogte2"
-		END
-		CLASS
-			EXPRESSION      {transitie,perron,open verharding,gesloten verharding,half verhard}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#FFFFFF"
-				OUTLINECOLOR  "#FFFFFF"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      {erf,onverhard}
-			STYLE
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   2000
-				COLOR         "#F9F9E7"
-				OUTLINECOLOR  "#F9F9E7"
-			END
-			STYLE
-			MAXSCALEDENOM   2000
-			MINSCALEDENOM   0
-				COLOR         "#F9F9E7"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      {groenvoorziening,struiken}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#DCEACF"
-				OUTLINECOLOR  "#DCEACF"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+
+    LAYER
+        NAME                    onbegroeideterreindelen_vlak2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_fysiek_voorkomen, id from public.bgt_onbegroeideterreindelen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        CLASSITEM               "bgt_fysiek_voorkomen"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "onbegroeideterreindelen_vlak2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            EXPRESSION          {erf,onverhard,zand}
+            STYLE
+                MAXSCALEDENOM   5000
+                MINSCALEDENOM   2500
+                COLOR           "#F9F9E7"
+                OUTLINECOLOR    "#F9F9E7"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+            STYLE
+                MAXSCALEDENOM   2500
+            MINSCALEDENOM   0
+                COLOR           "#F9F9E7"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          {open verharding,gesloten verharding,transitie,half verhard}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#FFFFFF"
+                OUTLINECOLOR    "#FFFFFF"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
+    # Overbrugging 2
 
-  # Terreindeel 2 (begroeid)
-	LAYER
-		NAME                    begroeideterreindelen_vlak2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_begroeideterreindelen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_fysiek_voorkomen"
-		FILTER (("[bgt_fysiek_voorkomen]" = "erf") Or ("[bgt_fysiek_voorkomen]" = "zand") Or ("[bgt_fysiek_voorkomen]" = "onverhard") Or ("[bgt_fysiek_voorkomen]" = "houtwal") Or ("[bgt_fysiek_voorkomen]" = "kwelder") Or ("[bgt_fysiek_voorkomen]" = "heide") Or ("[bgt_fysiek_voorkomen]" = "strekdam") Or ("[bgt_fysiek_voorkomen]" = "rietland") Or ("[bgt_fysiek_voorkomen]" = "gesloten verharding") Or ("[bgt_fysiek_voorkomen]" = "half verhard" ) Or ("[bgt_fysiek_voorkomen]" = "perron") Or ("[bgt_fysiek_voorkomen]" = "transitie") Or ("[bgt_fysiek_voorkomen]" = "open verharding" ) Or ("[bgt_fysiek_voorkomen]" = "groenvoorziening") Or ("[bgt_fysiek_voorkomen]" = "struiken") Or ("[bgt_fysiek_voorkomen]" = "grasland overig" ) Or ("[bgt_fysiek_voorkomen]" = "grasland agrarisch" ) Or ("[bgt_fysiek_voorkomen]" = "naaldbos") Or ("[bgt_fysiek_voorkomen]" = "fruitteelt") Or ("[bgt_fysiek_voorkomen]" = "loofbos") Or ("[bgt_fysiek_voorkomen]" = "bouwland") Or ("[bgt_fysiek_voorkomen]" = "gemengd bos" ) Or ("[bgt_fysiek_voorkomen]" = "moeras") Or ("[bgt_fysiek_voorkomen]" = "boomteelt") Or ("[bgt_fysiek_voorkomen]" = "oever, slootkant") )
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "begroeideterreindelen_vlak2"
-			"wms_group_title"      "hoogte2"
-		END
-		CLASS
-			EXPRESSION      {transitie,perron,open verharding,gesloten verharding,half verhard}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#FFFFFF"
-				OUTLINECOLOR  "#FFFFFF"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      {erf,onverhard}
-			STYLE
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   2000
-				COLOR         "#F9F9E7"
-				OUTLINECOLOR  "#F9F9E7"
-			END
-			STYLE
-			MAXSCALEDENOM   2000
-			MINSCALEDENOM   0
-				COLOR         "#F9F9E7"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      {groenvoorziening,struiken}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM   0
-			STYLE
-				COLOR         "#DCEACF"
-				OUTLINECOLOR  "#DCEACF"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    overbruggingsdelen_vlak2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, id from public.bgt_overbruggingsdelen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "overbruggingsdelen_vlak2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#FFFFFF"
+                OUTLINECOLOR    "#FFFFFF"
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Berm achter 2
 
-	LAYER
-		NAME                    ondersteunendewegdelen_achter_2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_ondersteunendewegdelen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM           0
-		CLASSITEM				"bgt_fysiek_voorkomen"
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "ondersteunendewegdelen_achter_2"
-			"wms_group_title"      "hoogte2"
-		END
-		CLASS
-			EXPRESSION      {open verharding,gesloten verharding,transitie,half verhard}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM    0
-			STYLE
-				COLOR         "#C9C7C2"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION     {groenvoorziening,onverhard}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM    0
-			STYLE
-				COLOR         "#C9C7C2"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    berm_achter_2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, id from public.bgt_ondersteunendewegdelen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "berm_achter_2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Berm voor 2
 
-	LAYER
-		NAME                    ondersteunendewegdelen_voor_2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_ondersteunendewegdelen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM           0
-		CLASSITEM				"bgt_fysiek_voorkomen"
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "ondersteunendewegdelen_voor_2"
-			"wms_group_title"      "hoogte2"
-		END
-		CLASS
-			EXPRESSION      {open verharding,gesloten verharding,transitie,half verhard}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM    0
-			STYLE
-				COLOR         "#F6F3F4"
-			END
-		END
-		CLASS
-			EXPRESSION     {groenvoorziening,onverhard}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM    0
-			STYLE
-				COLOR         "#DCEACF"
-			END
-		END
-	END
+    LAYER
+        NAME                    berm_voor_2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_fysiek_voorkomen, id from public.bgt_ondersteunendewegdelen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        CLASSITEM                "bgt_fysiek_voorkomen"
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "berm_voor_2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            EXPRESSION          {open verharding,gesloten verharding,transitie,half verhard}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#F6F3F4"
+            END
+        END
+        CLASS
+            EXPRESSION          {groenvoorziening,onverhard}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#DCEACF"
+                OUTLINECOLOR    "#DCEACF"
+                WIDTH           1
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Rijbanen achter 2
 
-	LAYER
-			NAME                    rijbanen_achter_2
-			GROUP                   hoogte2
-			INCLUDE                 "connection/dataservices.inc"
-			DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-			TYPE                    POLYGON
-			CLASSITEM               "bgt_functie"
-			FILTER 					((((("[bgt_functie]" = "fietspad") Or (("[bgt_functie]" = "inrit") Or (("[bgt_functie]" = "OV-baan") Or (("[bgt_functie]" = "overweg") Or (("[bgt_functie]" = "rijbaan autoweg") Or (("[bgt_functie]" = "rijbaan lokale weg") Or (("[bgt_functie]" = "rijbaan regionale weg") Or (("[bgt_functie]" = "transitie") Or (("[bgt_functie]" = "baan voor vliegverkeer") Or ("[bgt_functie]" = "parkeervlak")))))))))))))
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			0
-			PROJECTION
-				"init=epsg:28992"
-			END
-			METADATA
-				"wms_title"            "rijbanen_achter_2"
-				"wms_group_title"      "hoogte2"
-			END
-			CLASS
-				EXPRESSION      {parkeervlak,rijbaan lokale weg,fietspad,inrit,transitie,rijbaan autoweg,rijbaan regionale weg,OV-baan,overweg,baan voor vliegverkeer}
-				MAXSCALEDENOM   3500
-				MINSCALEDENOM			0
-				STYLE
-					COLOR         "#C9C7C2"
-					OUTLINECOLOR  "#C9C7C2"
-					WIDTH         1.8
-					LINECAP       BUTT
-					LINEJOIN      MITER
-				END
-			END
-		END
+    LAYER
+        NAME                    rijbanen_achter_2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "fietspad,inrit,OV-baan,overweg,rijbaan autoweg,rijbaan lokale weg,rijbaan regionale weg,transitie,parkeervlak")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "rijbanen_achter_2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1.8
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
   #-----------------------------------------------------------------------------
   # Rijbanen voor 2
 
-	LAYER
-		NAME                    rijbanen_voor_2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_functie"
-		FILTER 					((((("[bgt_functie]" = "fietspad") Or (("[bgt_functie]" = "inrit") Or (("[bgt_functie]" = "OV-baan") Or (("[bgt_functie]" = "overweg") Or (("[bgt_functie]" = "rijbaan autoweg") Or (("[bgt_functie]" = "rijbaan lokale weg") Or (("[bgt_functie]" = "rijbaan regionale weg") Or (("[bgt_functie]" = "transitie") Or (("[bgt_functie]" = "baan voor vliegverkeer") Or ("[bgt_functie]" = "parkeervlak")))))))))))))
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "rijbanen_voor_2"
-			"wms_group_title"      "hoogte2"
-		END
-		 CLASS
-			EXPRESSION      {parkeervlak,rijbaan lokale weg,fietspad,inrit,transitie,rijbaan autoweg,rijbaan regionale weg,OV-baan,overweg,baan voor vliegverkeer}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#FFFFFF"
-			END
-		END
-	END
-
- #-----------------------------------------------------------------------------
-  # Parkeervlakken 2
-
-  LAYER
-	NAME                    parkeervlak2
-	GROUP                   hoogte2
-	INCLUDE                 "connection/dataservices.inc"
-	DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '2' and eind_registratie isnull and bgt_functie = 'parkeervlak') As subquery USING srid=28992 USING UNIQUE id"
-	TYPE                    POLYGON
-	MAXSCALEDENOM           3500
-	MINSCALEDENOM			0
-	PROJECTION
-		"init=epsg:28992"
-	END
-	METADATA
-		"wms_title"            "parkeervlak2"
-		"wms_group_title"      "hoogte2"
-	END
-	CLASS
-		MAXSCALEDENOM   3500
-		MINSCALEDENOM			0
-		STYLE
-			COLOR         "#C9C7C2"
-			OUTLINECOLOR  "#C9C7C2"
-			WIDTH         1
-			LINECAP       BUTT
-			LINEJOIN      MITER
-		END
-		STYLE
-			COLOR         "#FFFFFF"
-		END
-	END
-END
+    LAYER
+        NAME                    rijbanen_voor_2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "fietspad,inrit,OV-baan,overweg,rijbaan autoweg,rijbaan lokale weg,rijbaan regionale weg,transitie,parkeervlak")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "rijbanen_voor_2"
+            "wms_group_title"   "hoogte2"
+        END
+         CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR         "#FFFFFF"
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Voetgangers achter 2
 
-	LAYER
-		NAME                    voetgangers_achter_2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_functie"
-		FILTER ((((("[bgt_functie]" = "ruiterpad") Or (("[bgt_functie]" = "voetpad") Or (("[bgt_functie]" = "voetgangersgebied") Or (("[bgt_functie]" = "voetpad op trap") Or (("[bgt_functie]" = "woonerf") Or ("[bgt_functie]" = "verkeerseiland")))))))))
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "voetgangers_achter_2"
-			"wms_group_title"      "hoogte2"
-		END
-		CLASS
-			EXPRESSION      {voetpad op trap,voetpad,verkeerseiland,voetgangersgebied,woonerf,ruiterpad}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#C9C7C2"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    voetgangers_achter_2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "ruiterpad,voetpad,voetgangersgebied,voetpad op trap,woonerf")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "voetgangers_achter_2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Voetgangers voor 2
 
-	LAYER
-		NAME                    voetgangers_voor_2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		FILTER ((((("[bgt_functie]" = "ruiterpad") Or (("[bgt_functie]" = "voetpad") Or (("[bgt_functie]" = "voetgangersgebied") Or (("[bgt_functie]" = "voetpad op trap") Or (("[bgt_functie]" = "woonerf") Or ("[bgt_functie]" = "verkeerseiland")))))))))
-		CLASSITEM               "bgt_functie"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "voetgangers_voor_2"
-			"wms_group_title"      "hoogte2"
-		END
-		CLASS
-			EXPRESSION      {voetpad op trap,voetpad,verkeerseiland,voetgangersgebied,woonerf,ruiterpad}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#f7f3f5"
-			END
-		END
-	END
+    LAYER
+        NAME                    voetgangers_voor_2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "ruiterpad,voetpad,voetgangersgebied,voetpad op trap,woonerf")
+        CLASSITEM               "bgt_functie"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "voetgangers_voor_2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            EXPRESSION          {voetpad op trap,voetpad,verkeerseiland,voetgangersgebied,woonerf,ruiterpad}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#f7f3f5"
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
-  # Gebouw 2
+    # Kunstwerkdeel vlak 2
 
-  LAYER
-	NAME                    overigebouwerken_vlak2
-	GROUP                   hoogte2
-	INCLUDE                 "connection/dataservices.inc"
-	DATA                    "geometrie FROM (select * from public.bgt_overigebouwwerken where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-	TYPE                    POLYGON
-	CLASSITEM               "bgt_type"
-	MAXSCALEDENOM           3500
-	MINSCALEDENOM			0
-	PROJECTION
-		"init=epsg:28992"
-	END
-	METADATA
-		"wms_title"            "overigebouwerken_vlak2"
-		"wms_group_title"      "hoogte2"
-	END
-		CLASS
-			EXPRESSION      {niet-bgt,transitie,lage trafo,open loods,opslagtank,bassin,windturbine,bezinkbak}
-			STYLE
-				MAXSCALEDENOM   3500
-				MINSCALEDENOM	0
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      "bestaand"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      "overkapping"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				OPACITY       50
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    inrichtingselement_vlak2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_type, id from public.bgt_kunstwerkdelen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_type]" ne "niet-bgt")
+        CLASSITEM               "bgt_type"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM            0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "inrichtingselement_vlak2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            EXPRESSION          {hoogspanningsmast,sluis,gemaal,stuw}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM        0
+            STYLE
+                COLOR           "#C9C7C2"
+            END
+        END
+        CLASS
+            EXPRESSION          {perron,strekdam}
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#f7f3f5"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          "steiger"
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM        0
+            STYLE
+                COLOR           "#F2F1EE"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
-	#-----------------------------------------------------------------------------
-	# Gebouwinstallaties (hierin vallen luivels, trappen etc)
+    #-----------------------------------------------------------------------------
+    # Scheiding vlak 2
 
-	LAYER
-		NAME                    gebouwinstallaties2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_gebouwinstallaties where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "gebouwinstallaties2"
-			"wms_group_title"      "hoogte2"
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		
-	END
+    LAYER
+        NAME                    scheiding_vlak2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_type, id from public.bgt_scheidingen where geometrie_vlak IS NOT NULL and relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_type]" = "muur")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "scheiding_vlak2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#E0DED8"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
-	  #-----------------------------------------------------------------------------
-	  # Panden (dit was een onderdeel van 'gebouw') (nu hier los uit de bgt gehaald, nog even fixen)
+    #-----------------------------------------------------------------------------
+    # Gebouw 2
 
-	  LAYER
-		NAME                    panden_vlak2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_panden where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_status"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "panden_vlak2"
-			"wms_group_title"      "hoogte2"
-		END
-		CLASS
-			EXPRESSION      "bestaand"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		
-	END
+    LAYER
+        NAME                    gebouw_vlak2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_type, id from public.bgt_overigebouwwerken where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        CLASSITEM               "bgt_type"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "gebouw_vlak2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            EXPRESSION          {niet-bgt,transitie,lage trafo,open loods,opslagtank,windturbine}
+            STYLE
+                MAXSCALEDENOM   5000
+                MINSCALEDENOM   0
+                COLOR           "#E0DED8"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          {bassin,bezinkbak}
+            STYLE
+                MAXSCALEDENOM   5000
+                MINSCALEDENOM   0
+                COLOR           "#95C6D5"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           2
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            EXPRESSION          "overkapping"
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                OPACITY         50
+                COLOR           "#E0DED8"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
+    #-----------------------------------------------------------------------------
+    # Panden 2
 
-  #-----------------------------------------------------------------------------
-  # Inrichtingselement vlak 2
-
-	LAYER
-		NAME                    inrichtingselement_vlak2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_kunstwerkdelen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE					POLYGON
-		FILTER (((("[bgt_type]" = "steiger") OR (("[bgt_type]" = "sluis") Or (("[bgt_type]" = "gemaal") Or ("[bgt_type]" = "stuw"))) OR ("[bgt_type]" = "muur"))))
-		CLASSITEM               "bgt_type"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "inrichtingselement_vlak2"
-			"wms_group_title"      "hoogte2"
-		END
-		CLASS
-			EXPRESSION           "steiger"
-			MAXSCALEDENOM 3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR             "#F2F1EE"
-				OUTLINECOLOR      "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION           "muur"
-			MAXSCALEDENOM 3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+      LAYER
+        NAME                    panden_vlak2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, id from public.bgt_panden where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "panden_vlak2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#E5E3DE"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.9
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END        
+    END
 
   #-----------------------------------------------------------------------------
   # Metro achter 2
 
-	LAYER
-		NAME                    metro_achter2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM               "bgt_functie"
-		FILTER					"sneltram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_achter2"
-			"wms_group_title"      "hoogte2"
-		END
-		CLASS
-				MAXSCALEDENOM           3500
-				MINSCALEDENOM			2000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-				MAXSCALEDENOM           2000
-				MINSCALEDENOM			0
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    metro_achter2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "sneltram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "metro_achter2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           3
+                OUTLINECOLOR    "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           3.5
+                OUTLINECOLOR    "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Metro voor 2
 
-	LAYER
-		NAME                    metro_voor2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM              "bgt_functie"
-		FILTER					"sneltram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_voor2"
-			"wms_group_title"      "hoogte2"
-		END
-		CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			2000
-			STYLE
-
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-		MAXSCALEDENOM           2000
-		MINSCALEDENOM		0
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    metro_voor2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "sneltram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "metro_voor2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           2
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           2.5
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Trein achter 2
 
-	LAYER
-		NAME                    trein_achter2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM               "bgt_functie"
-		FILTER					"trein"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_achter2"
-			"wms_group_title"      "hoogte2"
-		END
-		CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			2000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM           2000
-			MINSCALEDENOM			0
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    trein_achter2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "trein"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "trein_achter2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           3
+                OUTLINECOLOR    "#9D9D9D"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           3.5
+                OUTLINECOLOR    "#9D9D9D"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Trein voor 2
 
-	LAYER
-		NAME                    trein_voor2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		FILTERITEM               "bgt_functie"
-		FILTER					"trein"
-		TYPE 					LINE
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_voor2"
-			"wms_group_title"      "hoogte2"
-		END
-			CLASS
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			2000
-			STYLE
-
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-		MAXSCALEDENOM           2000
-				MINSCALEDENOM			0
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    trein_voor2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        FILTERITEM              "bgt_functie"
+        FILTER                  "trein"
+        TYPE                    LINE
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "trein_voor2"
+            "wms_group_title"   "hoogte2"
+        END
+            CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           2
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    8
+                    8
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           2.5
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    8
+                    8
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Snelweg achter 2
 
-	LAYER
-			NAME                    snelweg_achter_2
-			GROUP                   hoogte2
-			INCLUDE                 "connection/dataservices.inc"
-			DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-			TYPE                    POLYGON
-			FILTERITEM              "bgt_functie"
-			FILTER					"rijbaan autosnelweg"
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			0
-			PROJECTION
-				"init=epsg:28992"
-			END
-			METADATA
-				"wms_title"            "snelweg_achter_2"
-				"wms_group_title"      "hoogte2"
-			END
-			CLASS
-				MAXSCALEDENOM           3500
-				MINSCALEDENOM			0
-				STYLE
-					COLOR         "#C9C7C2"
-					OUTLINECOLOR  "#C9C7C2"
-					WIDTH         1
-					LINECAP       BUTT
-					LINEJOIN      MITER
-				END
-			END
-		END
+    LAYER
+        NAME                    snelweg_achter_2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTERITEM              "bgt_functie"
+        FILTER                  "rijbaan autosnelweg"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "snelweg_achter_2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+                STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+                END
+            END
+        END
   #-----------------------------------------------------------------------------
   # Snelweg voor 2
 
-	LAYER
-		NAME                    snelweg_voor_2
-		GROUP                   hoogte2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		FILTERITEM              "bgt_functie"
-		FILTER					"rijbaan autosnelweg"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "snelweg_voor_2"
-			"wms_group_title"      "hoogte2"
-		END
-		CLASS
-		 MAXSCALEDENOM           3500
-			MINSCALEDENOM			0
-		  STYLE
-			COLOR         "#FEFAFA"
-		  END
-		END
-	END
+    LAYER
+        NAME                    snelweg_voor_2
+        GROUP                   hoogte2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 2 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTERITEM              "bgt_functie"
+        FILTER                  "rijbaan autosnelweg"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "snelweg_voor_2"
+            "wms_group_title"   "hoogte2"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+          STYLE
+                COLOR           "#FEFAFA"
+          END
+        END
+    END
 
 #==============================================================================
 ## HOOGTELIGGING 3
 #==============================================================================
 
-# Terreindeel 3
+    # Terreindeel 3 (begroeid)
 
-	LAYER
-		NAME                    inrichtingselement_vlak3
-		GROUP                   hoogte3
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_kunstwerkdelen where relatieve_hoogteligging = '3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		FILTER (("[bgt_fysiekvoorkomen]" = "erf") Or ("[bgt_fysiekvoorkomen]" = "zand") Or ("[bgt_fysiekvoorkomen]" = "onverhard") Or ("[bgt_fysiekvoorkomen]" = "houtwal") Or ("[bgt_fysiekvoorkomen]" = "kwelder") Or ("[bgt_fysiekvoorkomen]" = "heide") Or ("[bgt_fysiekvoorkomen]" = "strekdam") Or ("[bgt_fysiekvoorkomen]" = "rietland") Or ("[bgt_fysiekvoorkomen]" = "gesloten verharding") Or ("[bgt_fysiekvoorkomen]" = "half verhard" ) Or ("[bgt_fysiekvoorkomen]" = "perron") Or ("[bgt_fysiekvoorkomen]" = "transitie") Or ("[bgt_fysiekvoorkomen]" = "open verharding" ) Or ("[bgt_fysiekvoorkomen]" = "groenvoorziening") Or ("[bgt_fysiekvoorkomen]" = "struiken") Or ("[bgt_fysiekvoorkomen]" = "grasland overig" ) Or ("[bgt_fysiekvoorkomen]" = "grasland agrarisch" ) Or ("[bgt_fysiekvoorkomen]" = "naaldbos") Or ("[bgt_fysiekvoorkomen]" = "fruitteelt") Or ("[bgt_fysiekvoorkomen]" = "loofbos") Or ("[bgt_fysiekvoorkomen]" = "bouwland") Or ("[bgt_fysiekvoorkomen]" = "gemengd bos" ) Or ("[bgt_fysiekvoorkomen]" = "moeras") Or ("[bgt_fysiekvoorkomen]" = "boomteelt") Or ("[bgt_fysiekvoorkomen]" = "oever, slootkant") )
-		CLASSITEM               "bgt_fysiek_voorkomen"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "inrichtingselement_vlak3"
-			"wms_group_title"      "hoogte3"
-		END
-		CLASS
-			EXPRESSION      "perron"
-			MAXSCALEDENOM   3500
-			STYLE
-				COLOR         "#FFFFFF"
-				OUTLINECOLOR  "#FFFFFF"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    #-----------------------------------------------------------------------------
+
+    # Terreindeel 3 (onbegroeid)
+
+    #-----------------------------------------------------------------------------
+
 
   #-----------------------------------------------------------------------------
   # Rijbanen achter 3
 
-	LAYER
-			NAME                    rijbanen_achter_3
-			GROUP                   hoogte3
-			INCLUDE                 "connection/dataservices.inc"
-			DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-			FILTER 					((((("[bgt_functie]" = "fietspad") Or (("[bgt_functie]" = "inrit") Or (("[bgt_functie]" = "OV-baan") Or (("[bgt_functie]" = "overweg") Or (("[bgt_functie]" = "rijbaan autoweg") Or (("[bgt_functie]" = "rijbaan lokale weg") Or (("[bgt_functie]" = "rijbaan regionale weg") Or (("[bgt_functie]" = "transitie") Or (("[bgt_functie]" = "baan voor vliegverkeer") Or ("[bgt_functie]" = "parkeervlak")))))))))))))
-			TYPE                    POLYGON
-			CLASSITEM               "bgt_functie"
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			0
-			PROJECTION
-				"init=epsg:28992"
-			END
-			METADATA
-				"wms_title"            "rijbanen_achter_3"
-				"wms_group_title"      "hoogte3"
-			END
-			CLASS
-				EXPRESSION      {parkeervlak,rijbaan lokale weg,fietspad,inrit,transitie,rijbaan autoweg,rijbaan regionale weg,OV-baan,overweg,baan voor vliegverkeer}
-				MAXSCALEDENOM   3500
-				MINSCALEDENOM			0
-				STYLE
-					COLOR         "#C9C7C2"
-					OUTLINECOLOR  "#C9C7C2"
-					WIDTH         1.8
-					LINECAP       BUTT
-					LINEJOIN      MITER
-				END
-			END
-		END
+    LAYER
+        NAME                    rijbanen_achter_3
+        GROUP                   hoogte3
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 3 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        FILTER                  ("[bgt_functie]" IN "fietspad,inrit,OV-baan,overweg,rijbaan autoweg,rijbaan lokale weg,rijbaan regionale weg,transitie,parkeervlak")
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "rijbanen_achter_3"
+            "wms_group_title"   "hoogte3"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+                STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1.8
+                LINECAP         BUTT
+                LINEJOIN        MITER
+                END
+            END
+        END
 
   #-----------------------------------------------------------------------------
   # Rijbanen voor 3
 
-	LAYER
-		NAME                    rijbanen_voor_3
-		GROUP                   hoogte3
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		FILTER 					((((("[bgt_functie]" = "fietspad") Or (("[bgt_functie]" = "inrit") Or (("[bgt_functie]" = "OV-baan") Or (("[bgt_functie]" = "overweg") Or (("[bgt_functie]" = "rijbaan autoweg") Or (("[bgt_functie]" = "rijbaan lokale weg") Or (("[bgt_functie]" = "rijbaan regionale weg") Or (("[bgt_functie]" = "transitie") Or (("[bgt_functie]" = "baan voor vliegverkeer") Or ("[bgt_functie]" = "parkeervlak")))))))))))))
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_functie"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "rijbanen_voor_3"
-			"wms_group_title"      "hoogte3"
-		END
-		CLASS
-			EXPRESSION      {parkeervlak,rijbaan lokale weg,fietspad,inrit,transitie,rijbaan autoweg,rijbaan regionale weg,OV-baan,overweg,baan voor vliegverkeer}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#FFFFFF"
-			END
-		END
-	END
+    LAYER
+        NAME                    rijbanen_voor_3
+        GROUP                   hoogte3
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 3 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        FILTER                  ("[bgt_functie]" IN "fietspad,inrit,OV-baan,overweg,rijbaan autoweg,rijbaan lokale weg,rijbaan regionale weg,transitie,parkeervlak")
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "rijbanen_voor_3"
+            "wms_group_title"   "hoogte3"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#FFFFFF"
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Voetgangers achter 3
 
-	LAYER
-		NAME                    voetganers_achter_3
-		GROUP                   hoogte3
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		FILTER ((((("[bgt_functie]" = "ruiterpad") Or (("[bgt_functie]" = "voetpad") Or (("[bgt_functie]" = "voetgangersgebied") Or (("[bgt_functie]" = "voetpad op trap") Or (("[bgt_functie]" = "woonerf") Or ("[bgt_functie]" = "verkeerseiland")))))))))
-		CLASSITEM               "bgt_functie"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "voetganers_achter_3"
-			"wms_group_title"      "hoogte3"
-		END
-		CLASS
-			EXPRESSION      {voetpad op trap,voetpad,verkeerseiland,voetgangersgebied,woonerf,ruiterpad}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#C9C7C2"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         1
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    voetganers_achter_3
+        GROUP                   hoogte3
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 3 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "ruiterpad,voetpad,voetgangersgebied,voetpad op trap,woonerf")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "voetganers_achter_3"
+            "wms_group_title"   "hoogte3"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Voetgangers voor 3
 
-	LAYER
-		NAME                    voetgangers_voor_3
-		GROUP                   hoogte3
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		FILTER ((((("[bgt_functie]" = "ruiterpad") Or (("[bgt_functie]" = "voetpad") Or (("[bgt_functie]" = "voetgangersgebied") Or (("[bgt_functie]" = "voetpad op trap") Or (("[bgt_functie]" = "woonerf") Or ("[bgt_functie]" = "verkeerseiland")))))))))
-		CLASSITEM               "bgt_functie"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "voetgangers_voor_3"
-			"wms_group_title"      "hoogte3"
-		END
-		CLASS
-			EXPRESSION      {voetpad op trap,voetpad,verkeerseiland,voetgangersgebied,woonerf,ruiterpad}
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM			0
-			STYLE
-				COLOR         "#f7f3f5"
-			END
-		END
-	END
+    LAYER
+        NAME                    voetgangers_voor_3
+        GROUP                   hoogte3
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 3 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_functie]" IN "ruiterpad,voetpad,voetgangersgebied,voetpad op trap,woonerf")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "voetgangers_voor_3"
+            "wms_group_title"   "hoogte3"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#f7f3f5"
+            END
+        END
+    END
+
+  #-----------------------------------------------------------------------------
+    # Kunstwerkdeel vlak 3
+
+    LAYER
+        NAME                    inrichtingselement_vlak3
+        GROUP                   hoogte3
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_type, id from public.bgt_kunstwerkdelen where relatieve_hoogteligging = 3 and  eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_type]" eq "perron")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "inrichtingselement_vlak3"
+            "wms_group_title"   "hoogte3"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#f7f3f5"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Gebouw 3
 
-	LAYER
-		NAME                    overigebouwerken_vlak3
-		GROUP                   hoogte3
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_overigebouwwerken where relatieve_hoogteligging = '3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_type"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "overigebouwerken_vlak3"
-			"wms_group_title"      "hoogte3"
-		END
-		CLASS
-			EXPRESSION      "overkapping"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				OPACITY       50
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      "niet-bgt"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			EXPRESSION      "bestaand"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    gebouw_vlak3
+        GROUP                   hoogte3
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_type, id from public.bgt_overigebouwwerken where relatieve_hoogteligging = 3 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_type]" = "overkapping")
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "gebouw_vlak3"
+            "wms_group_title"   "hoogte3"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                OPACITY         50
+                COLOR           "#E0DED8"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
-	#-----------------------------------------------------------------------------
-	# Gebouwinstallaties (hierin vallen luivels, trappen etc)
+    #-----------------------------------------------------------------------------
+    # Panden 3
 
-	LAYER
-		NAME                    gebouwinstallaties3
-		GROUP                   hoogte3
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_gebouwinstallaties where relatieve_hoogteligging = '3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "gebouwinstallaties3"
-			"wms_group_title"      "hoogte3"
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		
-	END
-
-	#-----------------------------------------------------------------------------
-	  # Panden (dit was een onderdeel van 'gebouw') (nu hier los uit de bgt gehaald, nog even fixen)
-
-	  LAYER
-		NAME                    panden_vlak3
-		GROUP                   hoogte3
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_panden where relatieve_hoogteligging = '3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_status"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "panden_vlak3"
-			"wms_group_title"      "hoogte3"
-		END
-		CLASS
-			EXPRESSION      "bestaand"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		
-	END
+      LAYER
+        NAME                    panden_vlak3
+        GROUP                   hoogte3
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, id from public.bgt_panden where relatieve_hoogteligging = 3 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "panden_vlak3"
+            "wms_group_title"   "hoogte3"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                COLOR           "#E5E3DE"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.9
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Metro achter 3
 
-	LAYER
-		NAME                    metro_achter3
-		GROUP                   hoogte3
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM               "bgt_functie"
-		FILTER					"sneltram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_achter3"
-			"wms_group_title"      "hoogte3"
-		END
-			CLASS
-				MAXSCALEDENOM           3500
-				MINSCALEDENOM			2000
-			STYLE
-				WIDTH 3
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-				MAXSCALEDENOM           2000
-				MINSCALEDENOM			0
-			STYLE
-				WIDTH 3.5
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    metro_achter3
+        GROUP                   hoogte3
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 3 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "sneltram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "metro_achter3"
+            "wms_group_title"   "hoogte3"
+        END
+            CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2000
+            STYLE
+                WIDTH           3
+                OUTLINECOLOR    "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           3.5
+                OUTLINECOLOR    "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Metro voor 3
 
-	LAYER
-		NAME                    metro_voor3
-		GROUP                   hoogte3
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM              "bgt_functie"
-		FILTER					"sneltram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_voor2"
-			"wms_group_title"      "hoogte3"
-		END
-		CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			2000
-			STYLE
-
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-		MAXSCALEDENOM           2000
-		MINSCALEDENOM		0
-			STYLE
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    metro_voor3
+        GROUP                   hoogte3
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = 3 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "sneltram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "metro_voor2"
+            "wms_group_title"   "hoogte3"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           2
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           2.5
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Snelweg achter 3
 
-	LAYER
-			NAME                    snelweg_achter3
-			GROUP                   hoogte3
-			INCLUDE                 "connection/dataservices.inc"
-			DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-			TYPE                    POLYGON
-			TYPE                    POLYGON
-			FILTERITEM              "bgt_functie"
-			FILTER					"rijbaan autosnelweg"
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			0
-			PROJECTION
-				"init=epsg:28992"
-			END
-			METADATA
-				"wms_title"            "snelweg_achter_3"
-				"wms_group_title"      "hoogte3"
-			END
-			CLASS
-				MAXSCALEDENOM           3500
-				MINSCALEDENOM			0
-				STYLE
-					COLOR         "#C9C7C2"
-					OUTLINECOLOR  "#C9C7C2"
-					WIDTH         1
-					LINECAP       BUTT
-					LINEJOIN      MITER
-				END
-			END
-		END
+    LAYER
+        NAME                    snelweg_achter3
+        GROUP                   hoogte3
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 3 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTERITEM              "bgt_functie"
+        FILTER                  "rijbaan autosnelweg"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+            PROJECTION
+                "init=epsg:28992"
+            END
+            METADATA
+            "wms_title"         "snelweg_achter_3"
+            "wms_group_title"   "hoogte3"
+            END
+            CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+                STYLE
+                COLOR           "#C9C7C2"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           1
+                LINECAP         BUTT
+                LINEJOIN        MITER
+                END
+            END
+        END
 
   #-----------------------------------------------------------------------------
   # Snelweg voor 3
 
-	LAYER
-		NAME                    snelweg_voor3
-		GROUP                   hoogte3
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_wegdelen where relatieve_hoogteligging = '3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		FILTERITEM              "bgt_functie"
-		FILTER					"rijbaan autosnelweg"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "snelweg_voor_3"
-			"wms_group_title"      "vlakken"
-		END
-		CLASS
-		 MAXSCALEDENOM           3500
-			MINSCALEDENOM			0
-		  STYLE
-			COLOR         "#FEFAFA"
-		  END
-		END
-	END
+    LAYER
+        NAME                    snelweg_voor3
+        GROUP                   hoogte3
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_functie, id from public.bgt_wegdelen where relatieve_hoogteligging = 3 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTERITEM              "bgt_functie"
+        FILTER                  "rijbaan autosnelweg"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "snelweg_voor_3"
+            "wms_group_title"   "hoogte3"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+          STYLE
+                COLOR           "#FEFAFA"
+          END
+        END
+    END
 
 
 #==============================================================================
 ## HOOGTELIGGING 4
 #==============================================================================
 
-
-  #-----------------------------------------------------------------------------
   # Gebouw 4 (hoogteligging 4 bestaat alleen voor overkapping in overig bouwerk)
 
-	LAYER
-		NAME                    overigebouwerken_vlak4
-		GROUP                   hoogte4
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_overigebouwwerken where relatieve_hoogteligging = '4' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		CLASSITEM               "bgt_type"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "overigebouwerken_vlak4"
-			"wms_group_title"      "hoogte4"
-		END
-		CLASS
-			EXPRESSION      "overkapping"
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				OPACITY       50
-				COLOR         "#E0DED8"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.5
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-	END
-
-
-
-#==============================================================================
-# LIJNEN
-#==============================================================================
+    LAYER
+        NAME                    gebouw_vlak4
+        GROUP                   hoogte4
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_vlak AS geometrie, bgt_type, id from public.bgt_overigebouwwerken where relatieve_hoogteligging = 4 and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    POLYGON
+        FILTER                  ("[bgt_type]" = 'overkapping')
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "gebouw_vlak2"
+            "wms_group_title"   "hoogte4"
+        END
+        CLASS
+            EXPRESSION          "overkapping"
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       0
+            STYLE
+                OPACITY         50
+                COLOR           "#E0DED8"
+                OUTLINECOLOR    "#C9C7C2"
+                WIDTH           0.5
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
 #==============================================================================
 ## HOOGTELIGGING -3
 #==============================================================================
 
 # Metro -3 (sporen bestaat van -3 tot 3)
-	LAYER
-		NAME                    metro_3
-		GROUP                   hoogte_3
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '-3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM				"bgt_functie"
-		FILTER 					"sneltram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_3"
-			"wms_group_title"      "hoogte_3"
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	2000
-			STYLE
-				WIDTH 1.5
-				OUTLINECOLOR "#FC7F7F"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM   2000
-			MINSCALEDENOM	0
-			STYLE
 
-				WIDTH 2
-				OUTLINECOLOR "#FC7F7F"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-
-
+    LAYER
+        NAME                    metro_3
+        GROUP                   hoogte_3
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = '-3' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "sneltram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "metro_3"
+            "wms_group_title"   "hoogte_3"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           1.5
+                OUTLINECOLOR    "#FC7F7F"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           2
+                OUTLINECOLOR    "#FC7F7F"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
 #==============================================================================
 ## HOOGTELIGGING -2
 #==============================================================================
 
 # Metro -2
-	LAYER
-		NAME                    metro_2
-		GROUP                   hoogte_2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '-2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM				"bgt_functie"
-		FILTER 					"sneltram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_2"
-			"wms_group_title"      "hoogte_2"
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	2000
-			STYLE
-				WIDTH 1.5
-				OUTLINECOLOR "#FC7F7F"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM   2000
-			MINSCALEDENOM	0
-			STYLE
 
-				WIDTH 2
-				OUTLINECOLOR "#FC7F7F"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    metro_2
+        GROUP                   hoogte_2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = '-2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "sneltram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "metro_2"
+            "wms_group_title"   "hoogte_2"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                WIDTH           1.5
+                OUTLINECOLOR    "#FC7F7F"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                WIDTH           2
+                OUTLINECOLOR    "#FC7F7F"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Trein -2
 
-	LAYER
-		NAME                    trein_2
-		GROUP                   hoogte_2
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '-2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM				"bgt_functie"
-		FILTER 					"trein"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_2"
-			"wms_group_title"      "hoogte_2"
-		END
-		CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			2000
-			STYLE
-
-				OPACITY 50
-				WIDTH 3
-				OUTLINECOLOR "#9D9D9D"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM           2000
-			MINSCALEDENOM			0
-			STYLE
-				OPACITY 50
-				WIDTH 3.5
-				OUTLINECOLOR "#9D9D9D"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-
-
+    LAYER
+        NAME                    trein_2
+        GROUP                   hoogte_2
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = '-2' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "trein"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "trein_2"
+            "wms_group_title"   "hoogte_2"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                OPACITY         50
+                WIDTH           3
+                OUTLINECOLOR    "#9D9D9D"
+                PATTERN
+                    8
+                    8
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                OPACITY         50
+                WIDTH           3.5
+                OUTLINECOLOR    "#9D9D9D"
+                PATTERN
+                    8
+                    8
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
 #==============================================================================
 ## HOOGTELIGGING -1
 #==============================================================================
 
-
-	# Gebouwinstallaties (hierin vallen luivels, trappen etc) -1 
-
-	LAYER
-		NAME                    gebouwinstallaties_1
-		GROUP                   hoogte_1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_gebouwinstallaties where relatieve_hoogteligging = '-1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    POLYGON
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "gebouwinstallaties_1"
-			"wms_group_title"      "hoogte_1"
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	0
-			STYLE
-				COLOR         "#E5E3DE"
-				OUTLINECOLOR  "#C9C7C2"
-				WIDTH         0.9
-				LINECAP       BUTT
-				LINEJOIN      MITER
-			END
-		END
-		
-	END
-
-#===================================================================================
-
 # Metro achter -1
-	LAYER
-		NAME                    metro_achter_1
-		GROUP                   hoogte_1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '-1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM				"bgt_functie"
-		FILTER 					"sneltram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_achter_1"
-			"wms_group_title"      "hoogte_1"
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	2000
-			STYLE
-				OPACITY 50
-				WIDTH 2.5
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM   2000
-			MINSCALEDENOM	0
-			STYLE
-				OPACITY 50
-				WIDTH 3
-				OUTLINECOLOR "#FC7F7F"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+
+    LAYER
+        NAME                    metro_achter_1
+        GROUP                   hoogte_1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = '-1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "sneltram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "metro_achter_1"
+            "wms_group_title"   "hoogte_1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                OPACITY         50
+                WIDTH           2.5
+                OUTLINECOLOR    "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                OPACITY         50
+                WIDTH           3
+                OUTLINECOLOR    "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Metro voor -1
 
-	LAYER
-		NAME                    metro_voor_1
-		GROUP                   hoogte_1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '-1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM				"bgt_functie"
-		FILTER 					"sneltram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "metro_voor_1"
-			"wms_group_title"      "hoogte_1"
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	2000
-			STYLE
-				OPACITY 60
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM           2000
-			MINSCALEDENOM			0
-			STYLE
-				OPACITY 60
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					7
-					7
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    metro_voor_1
+        GROUP                   hoogte_1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = '-1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "sneltram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "metro_voor_1"
+            "wms_group_title"   "hoogte_1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                OPACITY         60
+                WIDTH           2
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                OPACITY         60
+                WIDTH           2.5
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    7
+                    7
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Tram  -1
 
-	LAYER
-		NAME                    tram_1
-		GROUP                   hoogte_1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '-1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM				"bgt_functie"
-		FILTER 					"tram"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "tram_1"
-			"wms_group_title"      "hoogte_1"
-		END
-		CLASS
-			MAXSCALEDENOM   3500
-			MINSCALEDENOM	2000
-			STYLE
-				OPACITY       50
-				WIDTH         1.5
-				COLOR         "#FC7F7F"
-				LINECAP       BUTT
-				LINEJOIN      MITER
-				PATTERN
-					5
-					5
-				END
-			END
-		END
-		CLASS
-			MAXSCALEDENOM   2000
-			MINSCALEDENOM			0
-			STYLE
-				OPACITY       50
-				WIDTH         2
-				COLOR         "#FC7F7F"
-				LINECAP       BUTT
-				LINEJOIN      MITER
-				PATTERN
-					5
-					5
-				END
-			END
-		END
-	END
+    LAYER
+        NAME                    tram_1
+        GROUP                   hoogte_1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = '-1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "tram"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "tram_1"
+            "wms_group_title"   "hoogte_1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                OPACITY         50
+                WIDTH           1.5
+                COLOR           "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+                PATTERN
+                    5
+                    5
+                END
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                OPACITY         50
+                WIDTH           2
+                COLOR           "#FC7F7F"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+                PATTERN
+                    5
+                    5
+                END
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Trein achter -1
 
-	LAYER
-		NAME                    trein_achter_1
-		GROUP                   hoogte_1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '-1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM				"bgt_functie"
-		FILTER 					"trein"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_achter_1"
-			"wms_group_title"      "hoogte_1"
-		END
-		CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			2000
-			STYLE
-				OPACITY 50
-				WIDTH 3
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM           2000
-			MINSCALEDENOM			0
-			STYLE
-				OPACITY 50
-				WIDTH 3.5
-				OUTLINECOLOR "#9D9D9D"
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
+    LAYER
+        NAME                    trein_achter_1
+        GROUP                   hoogte_1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = '-1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "trein"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "trein_achter_1"
+            "wms_group_title"   "hoogte_1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                OPACITY         50
+                WIDTH           3
+                OUTLINECOLOR    "#9D9D9D"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                OPACITY         50
+                WIDTH           3.5
+                OUTLINECOLOR    "#9D9D9D"
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
   #-----------------------------------------------------------------------------
   # Trein voor -1
 
-	LAYER
-		NAME                    trein_voor_1
-		GROUP                   hoogte_1
-		INCLUDE                 "connection/dataservices.inc"
-		DATA                    "geometrie FROM (select * from public.bgt_sporen where relatieve_hoogteligging = '-1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
-		TYPE                    LINE
-		FILTERITEM				"bgt_functie"
-		FILTER 					"trein"
-		MAXSCALEDENOM           3500
-		MINSCALEDENOM			0
-		PROJECTION
-			"init=epsg:28992"
-		END
-		METADATA
-			"wms_title"            "trein_voor_1"
-			"wms_group_title"      "hoogte_1"
-		END
-		CLASS
-			MAXSCALEDENOM           3500
-			MINSCALEDENOM			2000
-			STYLE
-				OPACITY 60
-				WIDTH 2
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-		CLASS
-			MAXSCALEDENOM           2000
-			MINSCALEDENOM			0
-			STYLE
-				OPACITY 60
-				WIDTH 2.5
-				OUTLINECOLOR "#FFFFFF"
-				PATTERN
-					8
-					8
-				END
-				LINECAP BUTT
-				LINEJOIN MITER
-			END
-		END
-	END
-
-
+    LAYER
+        NAME                    trein_voor_1
+        GROUP                   hoogte_1
+        INCLUDE                 "connection/dataservices.inc"
+        DATA                    "geometrie FROM (select geometrie_lijn AS geometrie, bgt_functie, id from public.bgt_sporen where relatieve_hoogteligging = '-1' and eind_registratie isnull) As subquery USING srid=28992 USING UNIQUE id"
+        TYPE                    LINE
+        FILTERITEM              "bgt_functie"
+        FILTER                  "trein"
+        MAXSCALEDENOM           5000
+        MINSCALEDENOM           0
+        PROJECTION
+            "init=epsg:28992"
+        END
+        METADATA
+            "wms_title"         "trein_voor_1"
+            "wms_group_title"   "hoogte_1"
+        END
+        CLASS
+            MAXSCALEDENOM       5000
+            MINSCALEDENOM       2500
+            STYLE
+                OPACITY         60
+                WIDTH           2
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    8
+                    8
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+        CLASS
+            MAXSCALEDENOM       2500
+            MINSCALEDENOM       0
+            STYLE
+                OPACITY         60
+                WIDTH           2.5
+                OUTLINECOLOR    "#FFFFFF"
+                PATTERN
+                    8
+                    8
+                END
+                LINECAP         BUTT
+                LINEJOIN        MITER
+            END
+        END
+    END
 
 #=============================================================================
 END

--- a/referentiekaarten/kaartteksten.map
+++ b/referentiekaarten/kaartteksten.map
@@ -349,7 +349,7 @@ MAP
     DATA            "geometrie FROM (SELECT identificatie, type, geometrie_vlak AS geometrie FROM brt_25_pluslabels) AS sub USING srid=28992 using unique identificatie"
     FILTER          ("[type]" eq "provincie")
     TYPE            POLYGON
-    MINSCALEDENOM   6000
+    MINSCALEDENOM   5000
     MAXSCALEDENOM   10000
     PROJECTION
     "init=epsg:28992"
@@ -381,8 +381,8 @@ MAP
     DATA            "geometrie FROM (SELECT identificatie, type, geometrie_vlak AS geometrie FROM brt_25_pluslabels) AS sub USING srid=28992 using unique identificatie"
     FILTER          ("[type]" eq "stadsdeel")
     TYPE            POLYGON
-    MINSCALEDENOM   7000
-    MAXSCALEDENOM   14000
+    MINSCALEDENOM   10000
+    MAXSCALEDENOM   20000
     PROJECTION
     "init=epsg:28992"
     END
@@ -413,8 +413,8 @@ MAP
     DATA            "geometrie FROM (SELECT identificatie, type, geometrie_vlak AS geometrie FROM brt_25_pluslabels) AS sub USING srid=28992 using unique identificatie"
     FILTER          ("[type]" eq "water")
     TYPE            POLYGON
-    MINSCALEDENOM   4000
-    MAXSCALEDENOM   15000
+    MINSCALEDENOM   5000
+    MAXSCALEDENOM   20000
     PROJECTION
     "init=epsg:28992"
     END
@@ -445,8 +445,8 @@ MAP
     DATA            "geometrie FROM (SELECT identificatie, type, geometrie_vlak AS geometrie FROM brt_25_pluslabels) AS sub USING srid=28992 using unique identificatie"
     FILTER          ("[type]" eq "weg")
     TYPE            POLYGON
-    MINSCALEDENOM   4000
-    MAXSCALEDENOM   14000
+    MINSCALEDENOM   5000
+    MAXSCALEDENOM   20000
     PROJECTION
     "init=epsg:28992"
     END

--- a/referentiekaarten/kbk10.map
+++ b/referentiekaarten/kbk10.map
@@ -702,8 +702,8 @@ MAP
     MAXSCALEDENOM           20000
     MINSCALEDENOM           5000
     INCLUDE                 "connection/dataservices.inc"
-    DATA                    "geom FROM (SELECT identificatie, hoogteklasse, hoogteniveau, geometrie_vlak AS geom FROM brt_10_gebouwen) AS subquery USING srid=28992 USING UNIQUE identificatie"
-    FILTER                  ([hoogteniveau] >= 0 AND "[hoogteklasse]" eq "laagbouw")
+    DATA                    "geom FROM (SELECT identificatie, hoogteklasse, hoogteniveau, (string_to_array(type, '|'))[1] AS type, geometrie_vlak AS geom FROM brt_10_gebouwen) AS subquery USING srid=28992 USING UNIQUE identificatie"
+    FILTER                  ([hoogteniveau] >= 0 AND "[hoogteklasse]" eq "laagbouw" AND "[type]" ne "kas, warenhuis")
     TYPE                    POLYGON
     PROJECTION
       "init=epsg:28992"
@@ -1533,7 +1533,7 @@ END
     MINSCALEDENOM           5000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, aantal_sporen, hoogteniveau, type, geometrie_lijn AS geom FROM brt_10_spoorbaandelen) AS subquery USING srid=28992 USING UNIQUE identificatie"
-    FILTER                  ("[type]" eq "trein" AND [hoogteniveau] >= 0 AND "[aantal_sporen]" eq "enkel")
+    FILTER                  ("[type]" eq "metro" AND [hoogteniveau] >= 0 AND "[aantal_sporen]" eq "enkel")
     TYPE                    LINE
     PROJECTION
       "init=epsg:28992"

--- a/referentiekaarten/kbk50.map
+++ b/referentiekaarten/kbk50.map
@@ -12,6 +12,7 @@
 ## TRN_bedrijfsterrein_dienstverlening
 ## TRN_bos_groen_sport
 ## TRN_zand
+## TRN_kassengebied
 ## GBW_bebouwing
 ## GBW_kassen
 ## WDL_brede_waterloop
@@ -65,7 +66,7 @@ MAP
   LAYER
     NAME                    WDL_wateroppervlak
     GROUP                   "vlakken"
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, geometrie_vlak AS geom FROM brt_50_waterdelen WHERE geometrie_vlak IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -80,7 +81,7 @@ MAP
     END
 
     CLASS
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
       STYLE
         COLOR               "#95c6d5"
@@ -93,11 +94,11 @@ MAP
   LAYER
     NAME                    TRN_agrarisch
     GROUP                   "vlakken"
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type,geometrie_vlak AS geom FROM brt_50_terreinen WHERE geometrie_vlak IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
-    FILTER                  ("[type]" eq "akkerland")
+    FILTER                  ("[type]" eq "akkerland" || "[type]" eq "grasland")
     TYPE                    POLYGON
     PROJECTION
       "init=epsg:28992"
@@ -108,7 +109,7 @@ MAP
     END
 
     CLASS
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
       STYLE
         COLOR               "#dceacf"
@@ -121,7 +122,7 @@ MAP
   LAYER
     NAME                    TRN_overig
     GROUP                   "vlakken"
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type,geometrie_vlak AS geom FROM brt_50_terreinen WHERE geometrie_vlak IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -136,7 +137,7 @@ MAP
     END
 
     CLASS
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
       STYLE
         COLOR               "#f6f6f4"
@@ -149,7 +150,7 @@ MAP
   LAYER
     NAME                    TRN_bedrijfsterrein_dienstverlening
     GROUP                   "vlakken"
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type,geometrie_vlak AS geom FROM brt_50_plusterreinen WHERE geometrie_vlak IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -164,7 +165,7 @@ MAP
     END
 
     CLASS
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
       STYLE
         COLOR               "#d3d2cf"
@@ -183,11 +184,11 @@ MAP
   LAYER
     NAME                    TRN_bos_groen_sport
     GROUP                   "vlakken"
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
-    DATA                    "geom FROM (SELECT identificatie, type,geometrie_vlak AS geom FROM brt_50_terreinen WHERE geometrie_vlak IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
-    FILTER                  ("[type]" eq "bos: gemengd bos" || "[type]" eq "bos: loofbos" || "[type]" eq "bos: naaldbos" || "[type]" eq "bos: griend" || "[type]" eq "grasland")
+    DATA                    "geom FROM (SELECT identificatie, type, geometrie_vlak AS geom FROM brt_50_terreinen WHERE geometrie_vlak IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
+    FILTER                  ("[type]" eq "bos: gemengd bos" || "[type]" eq "bos: loofbos" || "[type]" eq "bos: naaldbos" || "[type]" eq "bos: griend" || "[type]" eq "boomkwekerij" || "[type]" eq "dodenakker")
     TYPE POLYGON
     PROJECTION
       "init=epsg:28992"
@@ -198,7 +199,7 @@ MAP
     END
 
     CLASS
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
       STYLE
         COLOR "#cbe0b8"
@@ -211,7 +212,7 @@ MAP
   LAYER
     NAME                    TRN_zand
     GROUP                   "vlakken"
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type, geometrie_vlak AS geom FROM brt_50_terreinen WHERE geometrie_vlak IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -226,7 +227,7 @@ MAP
     END
 
     CLASS
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
       STYLE
         COLOR               "#fbf0de"
@@ -234,15 +235,53 @@ MAP
     END
   END
 
+    #-----------------------------------------------------------------------------
+
+    LAYER
+      NAME                    TRN_kassengebied
+      GROUP                   "vlakken"
+      MAXSCALEDENOM           320000
+      MINSCALEDENOM           20000
+      INCLUDE                 "connection/dataservices.inc"
+      DATA                    "geom FROM (SELECT identificatie, type, geometrie_vlak AS geom FROM brt_50_terreinen WHERE geometrie_vlak IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
+      FILTER                  ("[type]" eq "kassengebied")
+      TYPE                    POLYGON
+      PROJECTION
+        "init=epsg:28992"
+      END
+
+      METADATA
+        "wms_title"           "TRN_kassengebied"
+      END
+
+      CLASS
+        MAXSCALEDENOM 320000
+        MINSCALEDENOM 20000
+        STYLE
+          COLOR "#e5e3de"
+        END
+      END
+      CLASS
+        MAXSCALEDENOM 80000
+        MINSCALEDENOM 20000
+        STYLE
+          WIDTH 0.7
+          OUTLINECOLOR "#e5e3de"
+          LINECAP BUTT
+          LINEJOIN MITER
+        END
+      END
+    END
+
   #-----------------------------------------------------------------------------
 
   LAYER
     NAME                    GBW_bebouwing
     GROUP                   "vlakken"
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
-    DATA                    "geom FROM (SELECT identificatie, type, geometrie_vlak AS geom FROM brt_50_gebouwen WHERE geometrie_vlak IS NOT NULL UNION ALL SELECT identificatie, type, geometrie_vlak AS geom FROM brt_50_terreinen WHERE geometrie_vlak IS NOT NULL AND type = 'bebouwd gebied') AS subquery USING srid=28992 USING UNIQUE identificatie"
+    DATA                    "geom FROM (SELECT identificatie, (string_to_array(type, '|'))[1] AS type, geometrie_vlak AS geom FROM brt_50_gebouwen WHERE geometrie_vlak IS NOT NULL UNION ALL SELECT identificatie, type, geometrie_vlak AS geom FROM brt_50_terreinen WHERE geometrie_vlak IS NOT NULL AND type = 'bebouwd gebied') AS subquery USING srid=28992 USING UNIQUE identificatie"
     FILTER                  ("[type]" ne "kas, warenhuis")
     TYPE POLYGON
     PROJECTION
@@ -254,14 +293,14 @@ MAP
     END
 
     CLASS
-      MAXSCALEDENOM 300000
+      MAXSCALEDENOM 320000
       MINSCALEDENOM 20000
       STYLE
         COLOR "#e5e3de"
       END
     END
     CLASS
-      MAXSCALEDENOM 50000
+      MAXSCALEDENOM 80000
       MINSCALEDENOM 20000
       STYLE
         WIDTH 0.7
@@ -277,10 +316,10 @@ MAP
   LAYER
     NAME                    GBW_kassen
     GROUP                   "vlakken"
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
-    DATA                    "geom FROM (SELECT identificatie, type, geometrie_vlak AS geom FROM brt_50_terreinen WHERE geometrie_vlak IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
+    DATA                    "geom FROM (SELECT identificatie, (string_to_array(type, '|'))[1] AS type, geometrie_vlak AS geom FROM brt_50_terreinen WHERE geometrie_vlak IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
     FILTER                  ("[type]" eq "kas, warenhuis")
     TYPE                    POLYGON
     PROJECTION
@@ -292,7 +331,7 @@ MAP
     END
 
     CLASS
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
       STYLE
         COLOR "#e3dbd3"
@@ -305,7 +344,7 @@ MAP
   LAYER
     NAME                    WDL_brede_waterloop
     GROUP                   "lijnen"
-    MAXSCALEDENOM           50000
+    MAXSCALEDENOM           80000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, breedteklasse, geometrie_lijn AS geom FROM brt_50_waterdelen WHERE geometrie_lijn IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -321,10 +360,10 @@ MAP
     END
 
     CLASS
-    MAXSCALEDENOM           50000
+    MAXSCALEDENOM           80000
     MINSCALEDENOM           20000
       STYLE
-        WIDTH 0.1
+        WIDTH 0.2
         OUTLINECOLOR "#95c6d5"
         LINECAP BUTT
         LINEJOIN MITER
@@ -337,7 +376,7 @@ MAP
   LAYER
     NAME                    WDL_smalle_waterloop
     GROUP                   "lijnen"
-    MAXSCALEDENOM           50000
+    MAXSCALEDENOM           80000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, breedteklasse, geometrie_lijn AS geom FROM brt_50_waterdelen WHERE geometrie_lijn IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -352,10 +391,10 @@ MAP
     END
 
     CLASS
-      MAXSCALEDENOM 50000
+      MAXSCALEDENOM 80000
       MINSCALEDENOM 20000
       STYLE
-        WIDTH 0.2
+        WIDTH 0.1
         COLOR "#95c6d5"
         LINECAP BUTT
         LINEJOIN MITER
@@ -368,7 +407,7 @@ MAP
   LAYER
     NAME                    WGL_straat_in_tunnel
     GROUP                   "lijnen"
-    MAXSCALEDENOM           75000
+    MAXSCALEDENOM           80000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type, geometrie_lijn AS geom FROM brt_50_wegdelen WHERE fysiek_voorkomen LIKE 'in tunnel%' AND geometrie_lijn IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -384,7 +423,7 @@ MAP
 
     CLASS
       # Zoom{=15}
-      MAXSCALEDENOM 25000
+      MAXSCALEDENOM 40000
       MINSCALEDENOM 20000
       STYLE
         WIDTH 2
@@ -399,8 +438,8 @@ MAP
     END
     CLASS
       # Zoom{=14}
-      MAXSCALEDENOM 75000
-      MINSCALEDENOM 25000
+      MAXSCALEDENOM 80000
+      MINSCALEDENOM 40000
       STYLE
         WIDTH 0.75
         PATTERN
@@ -419,7 +458,7 @@ MAP
   LAYER
     NAME                    WGL_hoofdweg_in_tunnel-case
     GROUP                   "lijnen"
-    MAXSCALEDENOM           100000
+    MAXSCALEDENOM           160000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type, geometrie_lijn AS geom FROM brt_50_wegdelen WHERE fysiek_voorkomen LIKE 'in tunnel%' AND geometrie_lijn IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -435,7 +474,7 @@ MAP
 
     CLASS
       # Zoom{=15}
-      MAXSCALEDENOM 25000
+      MAXSCALEDENOM 40000
       MINSCALEDENOM 20000
       STYLE
         WIDTH 4
@@ -450,8 +489,8 @@ MAP
     END
     CLASS
       # Zoom{=14}
-      MAXSCALEDENOM 50000
-      MINSCALEDENOM 25000
+      MAXSCALEDENOM 80000
+      MINSCALEDENOM 40000
       STYLE
         WIDTH 3
         PATTERN
@@ -465,8 +504,8 @@ MAP
     END
     CLASS
       # Zoom{=12 -13}
-      MAXSCALEDENOM 100000
-      MINSCALEDENOM 50000
+      MAXSCALEDENOM 160000
+      MINSCALEDENOM 80000
       STYLE
         WIDTH 2
         PATTERN
@@ -485,7 +524,7 @@ MAP
   LAYER
     NAME                    WGL_regionale_weg_in_tunnel-case
     GROUP                   "lijnen"
-    MAXSCALEDENOM           100000
+    MAXSCALEDENOM           160000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type, geometrie_lijn AS geom FROM brt_50_wegdelen WHERE fysiek_voorkomen LIKE 'in tunnel%' AND geometrie_lijn IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -501,7 +540,7 @@ MAP
 
     CLASS
       # Zoom{=15}
-      MAXSCALEDENOM 25000
+      MAXSCALEDENOM 40000
       MINSCALEDENOM 20000
       STYLE
         WIDTH 5
@@ -516,8 +555,8 @@ MAP
     END
     CLASS
       # Zoom{=14}
-      MAXSCALEDENOM 50000
-      MINSCALEDENOM 25000
+      MAXSCALEDENOM 80000
+      MINSCALEDENOM 40000
       STYLE
         WIDTH 4
         PATTERN
@@ -531,8 +570,8 @@ MAP
     END
     CLASS
       # Zoom{=13}
-      MAXSCALEDENOM 100000
-      MINSCALEDENOM 50000
+      MAXSCALEDENOM 160000
+      MINSCALEDENOM 80000
       STYLE
         WIDTH 2
         PATTERN
@@ -551,7 +590,7 @@ MAP
   LAYER
     NAME                    WGL_autosnelweg_in_tunnel-case
     GROUP                   "lijnen"
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type, geometrie_lijn AS geom FROM brt_50_wegdelen WHERE fysiek_voorkomen LIKE 'in tunnel%' AND geometrie_lijn IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -567,7 +606,7 @@ MAP
 
     CLASS
       # Zoom{=15}
-      MAXSCALEDENOM 50000
+      MAXSCALEDENOM 40000
       MINSCALEDENOM 20000
       STYLE
         WIDTH 2
@@ -582,8 +621,8 @@ MAP
     END
     CLASS
       # Zoom{=12 13}
-      MAXSCALEDENOM 300000
-      MINSCALEDENOM 50000
+      MAXSCALEDENOM 320000
+      MINSCALEDENOM 40000
       STYLE
         WIDTH 2
         PATTERN
@@ -602,7 +641,7 @@ MAP
   LAYER
     NAME                    WGL_regionale_weg_in_tunnel-fill
     GROUP                   "lijnen"
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type, geometrie_lijn AS geom FROM brt_50_wegdelen WHERE fysiek_voorkomen LIKE 'in tunnel%' AND geometrie_lijn IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -618,7 +657,7 @@ MAP
 
     CLASS
       # Zoom{=15}
-      MAXSCALEDENOM 50000
+      MAXSCALEDENOM 40000
       MINSCALEDENOM 20000
       STYLE
         WIDTH 3
@@ -629,8 +668,8 @@ MAP
     END
     CLASS
       # Zoom{=12 13}
-      MAXSCALEDENOM 300000
-      MINSCALEDENOM 50000
+      MAXSCALEDENOM 320000
+      MINSCALEDENOM 40000
       STYLE
         WIDTH 1
         COLOR "#ffffff"
@@ -645,7 +684,7 @@ MAP
   LAYER
     NAME                    WGL_autosnelweg_in_tunnel-fill
     GROUP                   "lijnen"
-    MAXSCALEDENOM           300000
+    MAXSCALEDENOM           320000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type, geometrie_lijn AS geom FROM brt_50_wegdelen WHERE fysiek_voorkomen LIKE 'in tunnel%' AND geometrie_lijn IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -661,7 +700,7 @@ MAP
 
     CLASS
       # Zoom{=15}
-      MAXSCALEDENOM 25000
+      MAXSCALEDENOM 40000
       MINSCALEDENOM 20000
       STYLE
         WIDTH 3
@@ -672,8 +711,8 @@ MAP
     END
     CLASS
       # Zoom{=14}
-      MAXSCALEDENOM 50000
-      MINSCALEDENOM 25000
+      MAXSCALEDENOM 80000
+      MINSCALEDENOM 40000
       STYLE
         WIDTH 2
         COLOR "#fefafaf0"
@@ -683,8 +722,8 @@ MAP
     END
     CLASS
       # Zoom{=13}
-      MAXSCALEDENOM 100000
-      MINSCALEDENOM 50000
+      MAXSCALEDENOM 160000
+      MINSCALEDENOM 80000
       STYLE
         WIDTH 1.5
         COLOR "#fefafaf0"
@@ -694,19 +733,8 @@ MAP
     END
     CLASS
       # Zoom{=12}
-      MAXSCALEDENOM 200000
-      MINSCALEDENOM 100000
-      STYLE
-        WIDTH 1
-        COLOR "#fefafaf0"
-        LINECAP BUTT
-        LINEJOIN MITER
-      END
-    END
-    CLASS
-      # Zoom{=11}
-      MAXSCALEDENOM 300000
-      MINSCALEDENOM 200000
+      MAXSCALEDENOM 320000
+      MINSCALEDENOM 160000
       STYLE
         WIDTH 1
         COLOR "#fefafaf0"
@@ -721,7 +749,7 @@ MAP
   LAYER
     NAME                    WGL_straat-case
     GROUP                   "lijnen"
-    MAXSCALEDENOM           75000
+    MAXSCALEDENOM           80000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type, geometrie_lijn AS geom FROM brt_50_wegdelen WHERE ((fysiek_voorkomen NOT LIKE 'in tunnel%' OR fysiek_voorkomen IS NULL) AND geometrie_lijn IS NOT NULL)) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -737,7 +765,7 @@ MAP
 
     CLASS
       # Zoom{=15}
-      MAXSCALEDENOM 25000
+      MAXSCALEDENOM 40000
       MINSCALEDENOM 20000
       STYLE
         WIDTH 3
@@ -748,8 +776,8 @@ MAP
     END
     CLASS
       # Zoom{=14}
-      MAXSCALEDENOM 75000
-      MINSCALEDENOM 25000
+      MAXSCALEDENOM 80000
+      MINSCALEDENOM 40000
       STYLE
         WIDTH 1.75
         COLOR "#c9c7c2"
@@ -764,7 +792,7 @@ MAP
   LAYER
     NAME                    WGL_hoofdweg-case
     GROUP                   "lijnen"
-    MAXSCALEDENOM           100000
+    MAXSCALEDENOM           160000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type, geometrie_lijn AS geom FROM brt_50_wegdelen WHERE ((fysiek_voorkomen NOT LIKE 'in tunnel%' OR fysiek_voorkomen IS NULL) AND geometrie_lijn IS NOT NULL)) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -780,7 +808,7 @@ MAP
 
     CLASS
       # Zoom{=15}
-      MAXSCALEDENOM 25000
+      MAXSCALEDENOM 40000
       MINSCALEDENOM 20000
       STYLE
         WIDTH 6
@@ -791,8 +819,8 @@ MAP
     END
     CLASS
       # Zoom{=14}
-      MAXSCALEDENOM 50000
-      MINSCALEDENOM 25000
+      MAXSCALEDENOM 80000
+      MINSCALEDENOM 40000
       STYLE
         WIDTH 4
         COLOR "#acacac"
@@ -802,8 +830,8 @@ MAP
     END
     CLASS
       # Zoom{=13}
-      MAXSCALEDENOM 100000
-      MINSCALEDENOM 50000
+      MAXSCALEDENOM 160000
+      MINSCALEDENOM 80000
       STYLE
         WIDTH 2
         COLOR "#acacac"
@@ -818,7 +846,7 @@ MAP
   LAYER
     NAME                    WGL_regionale_weg-case
     GROUP                   "lijnen"
-    MAXSCALEDENOM           100000
+    MAXSCALEDENOM           160000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type, geometrie_lijn AS geom FROM brt_50_wegdelen WHERE ((fysiek_voorkomen NOT LIKE 'in tunnel%' OR fysiek_voorkomen IS NULL) AND geometrie_lijn IS NOT NULL)) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -834,7 +862,7 @@ MAP
 
     CLASS
       # Zoom{=15}
-      MAXSCALEDENOM 25000
+      MAXSCALEDENOM 40000
       MINSCALEDENOM 20000
       STYLE
         WIDTH 4
@@ -845,8 +873,8 @@ MAP
     END
     CLASS
       # Zoom{=14}
-      MAXSCALEDENOM 50000
-      MINSCALEDENOM 25000
+      MAXSCALEDENOM 80000
+      MINSCALEDENOM 40000
       STYLE
         WIDTH 3
         COLOR "#acacac"
@@ -856,8 +884,8 @@ MAP
     END
     CLASS
       # Zoom{=13}
-      MAXSCALEDENOM 100000
-      MINSCALEDENOM 50000
+      MAXSCALEDENOM 160000
+      MINSCALEDENOM 80000
       STYLE
         WIDTH 2.5
         COLOR "#acacac"
@@ -872,7 +900,7 @@ MAP
   LAYER
     NAME                    WGL_straat-fill
     GROUP                   "lijnen"
-    MAXSCALEDENOM           40000
+    MAXSCALEDENOM           80000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type, geometrie_lijn AS geom FROM brt_50_wegdelen WHERE ((fysiek_voorkomen NOT LIKE 'in tunnel%' OR fysiek_voorkomen IS NULL) AND geometrie_lijn IS NOT NULL)) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -1016,23 +1044,11 @@ MAP
     END
     CLASS
       # Zoom{=12}
-      MAXSCALEDENOM 200000
+      MAXSCALEDENOM 320000
       MINSCALEDENOM 160000
       STYLE
         WIDTH 1
         COLOR "#ffffff"
-        LINECAP BUTT
-        LINEJOIN MITER
-      END
-    END
-    CLASS
-      # Zoom{=11}
-      MAXSCALEDENOM 300000
-      MINSCALEDENOM 200000
-      STYLE
-        WIDTH 0.75
-        COLOR "#ffffff"
-        OPACITY 80
         LINECAP BUTT
         LINEJOIN MITER
       END
@@ -1144,7 +1160,7 @@ MAP
   LAYER
     NAME                    SBL_trein_in_tunnel_line
     GROUP                   "lijnen"
-    MAXSCALEDENOM           100000
+    MAXSCALEDENOM           160000
     MINSCALEDENOM           20000
     INCLUDE                 "connection/dataservices.inc"
     DATA                    "geom FROM (SELECT identificatie, type, hoogteniveau, geometrie_lijn AS geom FROM brt_50_spoorbaandelen WHERE geometrie_lijn IS NOT NULL) AS subquery USING srid=28992 USING UNIQUE identificatie"
@@ -1474,7 +1490,7 @@ MAP
     END
 
     METADATA
-      "wms_title"           "WGL_autosnelweg-fill"
+      "wms_title"           "WGL_autosnelweg-centerline"
     END
 
     CLASS

--- a/sld/bgt_light.xml
+++ b/sld/bgt_light.xml
@@ -1,3536 +1,2998 @@
 <?xml version="1.0"?>
-<StyledLayerDescriptor 
-	xmlns="http://www.opengis.net/sld" 
-	xmlns:gml="http://www.opengis.net/gml" 
-	xmlns:ogc="http://www.opengis.net/ogc" 
-	xmlns:xlink="http://www.w3.org/1999/xlink" 
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
-	<NamedLayer>
-		<Name>metro_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-							<CssParameter name="stroke-dasharray">5 5 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-							<CssParameter name="stroke-dasharray">7 7 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-							<CssParameter name="stroke-dasharray">5 5 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-							<CssParameter name="stroke-dasharray">7 7 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-							<CssParameter name="stroke-dasharray">8 8 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-							<CssParameter name="stroke-dasharray">8 8 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_achter_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_voor_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>tram_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>tram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">1.2</CssParameter>
-							<CssParameter name="stroke-dasharray">4 4 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>tram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">2</CssParameter>
-							<CssParameter name="stroke-dasharray">4 4 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_achter_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_voor_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>waterdeel_vlak0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<MinScaleDenominator>0</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#B2CBD9</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#B2CBD9</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>terreindeel_vlak0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>erf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>onverhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>rietland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>zand</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>houtwal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>2000</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#E5EBD8</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>erf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>onverhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>rietland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>zand</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>houtwal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>groenvoorziening</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>grasland overig</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>grasland agrarisch</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>struiken</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D2E3BA</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#D2E3BA</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>oever</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>kwelder</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#E5EBD8</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>open verharding</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>gesloten verharding</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>half verhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>perron</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>strekdam</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#FFFFFF</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>loofbos</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>gemengd bos</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>bouwland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>moeras</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>fruitteelt</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>boomteelt</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>naaldbos</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D2E3BA</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#D2E3BA</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-							<ogc:Literal>heide</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#ddd6e5</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#ddd6e5</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>spoorbaan_overbrugging</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#FFFFFF</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>berm_achter_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>gesloten verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>half verhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F5F4F2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#F5F4F2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>groenvoorziening</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>onverhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#E5EBD8</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>berm_voor_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>gesloten verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>half verhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F5F4F2</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>groenvoorziening</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>onverhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_achter_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_voor_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FBFBFB</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#DEDCD9</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetganers_achter_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetgangers_voor_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F5F4F2</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>inrichtingselement_vlak0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>muur</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>sluis</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>gemaal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>stuw</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>steiger</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#F6F6F4</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>gebouw_vlak0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>bassin</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>bezinkbak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>lage trafo</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>niet-bgt</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>open loods</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>opslagtank</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>overkapping</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>windturbine</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>3500</MinScaleDenominator>
-					<MaxScaleDenominator>0</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<MinScaleDenominator>0</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.90</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_achter0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_voor0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>tram0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>tram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.2</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>tram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">2</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_achter0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_voor0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_achter_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#B4B4B4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#B4B4B4</CssParameter>
-							<CssParameter name="stroke-width">3.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_voor_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#EAEAAE</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer><Name>standplaats</Name><UserStyle><FeatureTypeStyle><Rule><MaxScaleDenominator>3500</MaxScaleDenominator><PolygonSymbolizer><Fill><CssParameter name="fill">#dcdcff</CssParameter></Fill><Stroke><CssParameter name="stroke">#afafaf</CssParameter><CssParameter name="stroke-width">1</CssParameter></Stroke></PolygonSymbolizer></Rule></FeatureTypeStyle></UserStyle></NamedLayer>
-	<NamedLayer><Name>ligplaats</Name><UserStyle><FeatureTypeStyle><Rule><MaxScaleDenominator>3500</MaxScaleDenominator><PolygonSymbolizer><Fill><CssParameter name="fill">#dcdcff</CssParameter></Fill><Stroke><CssParameter name="stroke">#afafaf</CssParameter><CssParameter name="stroke-width">1</CssParameter></Stroke></PolygonSymbolizer></Rule></FeatureTypeStyle></UserStyle></NamedLayer>
-	<NamedLayer>
-		<Name>wegdeel_vlak_tunnel</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-							<CssParameter name="fill-opacity">0.30</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>terreindeel_vlak1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>erf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>zand</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>onverhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>houtwal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>rietland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>2000</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#E5EBD8</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>erf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>zand</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>onverhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>houtwal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>rietland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>gesloten verharding</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>half verhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>perron</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>open verharding</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>strekdam</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#FFFFFF</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>groenvoorziening</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>struiken</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>grasland overig</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>grasland agrarisch</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D2E3BA</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>oever</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>kwelder</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#E5EBD8</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-<Rule>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#E5EBD8</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>berm_achter_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>gesloten verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>half verhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F5F4F2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#F5F4F2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>groenvoorziening</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>onverhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#E5EBD8</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>berm_voor_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>gesloten verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>half verhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F5F4F2</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>groenvoorziening</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>onverhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_achter_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_voor_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FBFBFB</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetganers_achter_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetgangers_voor_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F5F4F2</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>gebouw_vlak1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>bassin</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>bezinkbak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>lage trafo</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>niet-bgt</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>open loods</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>opslagtank</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>windturbine</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>3500</MinScaleDenominator>
-					<MaxScaleDenominator>0</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>overkapping</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-							<CssParameter name="fill-opacity">0.5</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<MinScaleDenominator>0</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.90</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>inrichtingselement_vlak1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>steiger</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>sluis</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>gemaal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>stuw</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>muur</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_achter1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_voor1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>tram1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>tram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.2</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>tram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">2</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_achter1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_voor1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_achter1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#B4B4B4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#B4B4B4</CssParameter>
-							<CssParameter name="stroke-width">3.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_voor1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#EAEAAE</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>terreindeel_vlak2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>erf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>zand</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>onverhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>houtwal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>duin</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>rietland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>2000</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#E5EBD8</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>erf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>zand</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>onverhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>houtwal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>duin</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>rietland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-							<ogc:Literal>gesloten verharding</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-							<ogc:Literal>perron</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-							<ogc:Literal>transitie</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-							<ogc:Literal>strekdam</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F5F4F2</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>oever</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>kwelder</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E5EBD8</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#E5EBD8</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>berm_achter_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>gesloten verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>half verhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F5F4F2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#F5F4F2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>groenvoorziening</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>onverhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D2E3BA</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#D2E3BA</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>berm_voor_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>gesloten verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>half verhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F5F4F2</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>groenvoorziening</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>onverhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D2E3BA</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_achter_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1.80</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_voor_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FBFBFB</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetgangers_achter_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetgangers_voor_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F5F4F2</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>gebouw_vlak2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>bassin</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>bezinkbak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>lage trafo</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>niet-bgt</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>open loods</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>opslagtank</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>windturbine</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>3500</MinScaleDenominator>
-					<MaxScaleDenominator>0</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>overkapping</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-							<CssParameter name="fill-opacity">0.5</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<MinScaleDenominator>0</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.90</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>inrichtingselement_vlak2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>steiger</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>muur</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_achter2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_voor2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_achter2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_voor2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_achter_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#B4B4B4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#B4B4B4</CssParameter>
-							<CssParameter name="stroke-width">3.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_voor_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#EAEAAE</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>terreindeel_vlak3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-							<ogc:Literal>perron</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_achter_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1.80</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_voor_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FBFBFB</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetganers_achter_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetgangers_voor_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F5F4F2</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>gebouw_vlak3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>niet-bgt</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>0</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>overkapping</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-							<CssParameter name="fill-opacity">0.5</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<MinScaleDenominator>0</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.90</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_achter3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_voor3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#BCB7D2</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_achter_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#B4B4B4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#B4B4B4</CssParameter>
-							<CssParameter name="stroke-width">3.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_voor_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#EAEAAE</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>gebouw_vlak4</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>overkapping</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#D9D9D4</CssParameter>
-							<CssParameter name="fill-opacity">0.5</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
+<StyledLayerDescriptor
+    version="1.0.0"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:gml="http://www.opengis.net/gml"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+    <NamedLayer>
+        <Name>waterdeel_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#B2CBD9</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#B2CBD9</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>ondersteunendewaterdelen_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#E5EBD8</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>begroeideterreindelen_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>rietland</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>duin</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>houtwal</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#E5EBD8</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>groenvoorziening</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>grasland overig</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>grasland agrarisch</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>struiken</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D2E3BA</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#D2E3BA</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                            <ogc:Literal>kwelder</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#E5EBD8</CssParameter>
+                            <CssParameter name="stroke-width">0.1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>loofbos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gemengd bos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>bouwland</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>moeras</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>fruitteelt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>boomteelt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>naaldbos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D2E3BA</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#D2E3BA</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                            <ogc:Literal>heide</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#ddd6e5</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#ddd6e5</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>onbegroeideterreindelen_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>erf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>zand</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#E5EBD8</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>erf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>zand</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gesloten verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>half verhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>perron</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>open verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>strekdam</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>overbruggingsdelen_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>berm_achter_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F5F4F2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F5F4F2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>berm_voor_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>open verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gesloten verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>half verhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F5F4F2</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>groenvoorziening</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_achter_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>fietspad</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>inrit</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>OV-baan</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>overweg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan autoweg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan lokale weg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan regionale weg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>overweg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>parkeervlak</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_voor_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>fietspad</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>inrit</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>OV-baan</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>overweg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan autoweg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan lokale weg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan regionale weg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>parkeervlak</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FBFBFB</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                            <ogc:Literal>baan voor vliegverkeer</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#DEDCD9</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_achter_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>ruiterpad</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>voetpad</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>voetgangersgebied</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>voetpad op trap</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>woonerf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_voor_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>ruiterpad</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>voetpad</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>voetgangersgebied</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>voetpad op trap</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>woonerf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F5F4F2</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>inrichtingselement_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>hoogspanningsmast</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>sluis</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>gemaal</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>stuw</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>perron</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>strekdam</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                            <ogc:Literal>steiger</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F6F6F4</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>scheiding_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>gebouw_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>lage trafo</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>niet-bgt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>open loods</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>opslagtank</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>overkapping</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>windturbine</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>bassin</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>bezinkbak</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#B2CBD9</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">2</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>panden_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E4E3DF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.9</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_achter0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_voor0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>tram0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.2</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">2</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_achter0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_voor0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_achter_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#B4B4B4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#B4B4B4</CssParameter>
+                            <CssParameter name="stroke-width">3.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_voor_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#EAEAAE</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>ligplaats</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#dcdcff</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#afafaf</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>standplaats</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#dcdcff</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#afafaf</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>wegdeel_vlak_tunnel</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan autoweg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan lokale weg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan regionale weg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                            <CssParameter name="fill-opacity">0.30</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>begroeideterreindelen_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>rietland</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>duin</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>houtwal</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#E5EBD8</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>groenvoorziening</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>grasland overig</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>grasland agrarisch</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>struiken</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D2E3BA</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#D2E3BA</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                            <ogc:Literal>kwelder</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#E5EBD8</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>loofbos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gemengd bos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>bouwland</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>moeras</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>fruitteelt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>boomteelt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>naaldbos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D2E3BA</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#D2E3BA</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                            <ogc:Literal>heide</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#ddd6e5</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#ddd6e5</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>onbegroeideterreindelen_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>erf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>zand</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#E5EBD8</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>erf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>zand</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gesloten verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>half verhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>perron</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>open verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>strekdam</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>overbruggingsdelen_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>berm_achter_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F5F4F2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F5F4F2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>berm_voor_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gesloten verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>half verhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>open verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F5F4F2</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>groenvoorziening</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_achter_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_voor_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FBFBFB</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_achter_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_voor_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F5F4F2</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>inrichtingselement_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>hoogspanningsmast</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>sluis</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>gemaal</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>stuw</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>perron</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>strekdam</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                            <ogc:Literal>steiger</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F6F6F4</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>scheiding_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>gebouw_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>lage trafo</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>niet-bgt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>open loods</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>opslagtank</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>overkapping</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>windturbine</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>bassin</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>bezinkbak</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#B2CBD9</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">2</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>panden_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E4E3DF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.9</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_achter1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_voor1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>tram1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.2</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">2</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_achter1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_voor1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                            <ogc:Literal>trein</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_achter1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#B4B4B4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#B4B4B4</CssParameter>
+                            <CssParameter name="stroke-width">3.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_voor1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#EAEAAE</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>begroeideterreindelen_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>rietland</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>duin</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>houtwal</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#E5EBD8</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>groenvoorziening</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>grasland overig</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>grasland agrarisch</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>struiken</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D2E3BA</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#D2E3BA</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                            <ogc:Literal>kwelder</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#E5EBD8</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>loofbos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gemengd bos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>bouwland</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>moeras</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>fruitteelt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>boomteelt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>naaldbos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D2E3BA</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#D2E3BA</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                            <ogc:Literal>heide</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#ddd6e5</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#ddd6e5</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>onbegroeideterreindelen_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>erf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>zand</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#E5EBD8</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>erf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>zand</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E5EBD8</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gesloten verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>half verhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>perron</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>open verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>strekdam</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>overbruggingsdelen_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>berm_achter_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F5F4F2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F5F4F2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>berm_voor_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gesloten verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>half verhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>open verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F5F4F2</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>groenvoorziening</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D2E3BA</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_achter_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1.80</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_voor_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FBFBFB</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_achter_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_voor_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F5F4F2</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>inrichtingselement_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>hoogspanningsmast</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>sluis</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>gemaal</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>stuw</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>perron</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>strekdam</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                            <ogc:Literal>steiger</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F6F6F4</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>scheiding_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>gebouw_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>lage trafo</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>niet-bgt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>open loods</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>opslagtank</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>overkapping</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>windturbine</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>bassin</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>bezinkbak</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#B2CBD9</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">2</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>panden_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E4E3DF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.9</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_achter2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_voor2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_achter2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_voor2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_achter_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#B4B4B4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#B4B4B4</CssParameter>
+                            <CssParameter name="stroke-width">3.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_voor_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#EAEAAE</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_achter_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1.80</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_voor_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FBFBFB</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_achter_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_voor_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F5F4F2</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>inrichtingselement_vlak3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>gebouw_vlak3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                            <CssParameter name="fill-opacity">0.5</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>panden_vlak3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E4E3DF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.9</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_achter3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_voor3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_achter_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#B4B4B4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#B4B4B4</CssParameter>
+                            <CssParameter name="stroke-width">3.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_voor_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#EAEAAE</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>gebouw_vlak4</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#D9D9D4</CssParameter>
+                            <CssParameter name="fill-opacity">0.5</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                            <CssParameter name="stroke-dasharray">5 5 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                            <CssParameter name="stroke-dasharray">7 7 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                            <CssParameter name="stroke-dasharray">5 5 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                            <CssParameter name="stroke-dasharray">7 7 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                            <CssParameter name="stroke-dasharray">8 8 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                            <CssParameter name="stroke-dasharray">8 8 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_achter_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_voor_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>tram_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">1.2</CssParameter>
+                            <CssParameter name="stroke-dasharray">4 4 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">2</CssParameter>
+                            <CssParameter name="stroke-dasharray">4 4 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_achter_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_voor_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#BCB7D2</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
 </StyledLayerDescriptor>

--- a/sld/bgt_zw.xml
+++ b/sld/bgt_zw.xml
@@ -1,3518 +1,2998 @@
 <?xml version="1.0"?>
-<StyledLayerDescriptor 
-	xmlns="http://www.opengis.net/sld" 
-	xmlns:gml="http://www.opengis.net/gml" 
-	xmlns:ogc="http://www.opengis.net/ogc" 
-	xmlns:xlink="http://www.w3.org/1999/xlink" 
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
-	<NamedLayer>
-		<Name>metro_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-							<CssParameter name="stroke-dasharray">5 6 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-							<CssParameter name="stroke-dasharray">7 7 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-							<CssParameter name="stroke-dasharray">5 6 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-							<CssParameter name="stroke-dasharray">7 7 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-							<CssParameter name="stroke-dasharray">8 8 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-							<CssParameter name="stroke-dasharray">8 8 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_achter_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_voor_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>tram_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>tram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">1.2</CssParameter>
-							<CssParameter name="stroke-dasharray">4 4 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>tram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">2</CssParameter>
-							<CssParameter name="stroke-dasharray">5 5 </CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_achter_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_voor_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-opacity">0.5</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>waterdeel_vlak0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<MinScaleDenominator>0</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#BEBEBE</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#BEBEBE</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>terreindeel_vlak0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>erf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>zand</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>onverhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>houtwal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>rietland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>2000</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F0F0F0</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#F0F0F0</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>erf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>zand</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>onverhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>houtwal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>rietland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F0F0F0</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>gesloten verharding</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>half verhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>perron</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>open verharding</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#FFFFFF</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>groenvoorziening</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>struiken</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>grasland agrarisch</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>grasland overig</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#EDECE9</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#EDECE9</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>naaldbos</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>fruitteelt</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>loofbos</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>bouwland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>gemengd bos</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>moeras</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>boomteelt</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#DCDCDC</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#DCDCDC</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>oever</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>kwelder</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>heide</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F0F0F0</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#F0F0F0</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>spoorbaan_overbrugging</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#FFFFFF</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>berm_achter_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>gesloten verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>half verhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FBFBFB</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#FBFBFB</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>groenvoorziening</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>onverhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#EDECE9</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#EDECE9</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>berm_voor_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>gesloten verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>half verhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FBFBFB</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>groenvoorziening</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>onverhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#EDECE9</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_achter_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_voor_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#DEDCD9</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetganers_achter_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetgangers_voor_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F6F6F4</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>inrichtingselement_vlak0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>steiger</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F6F6F4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>sluis</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>gemaal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>stuw</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>muur</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E6E5E0</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>gebouw_vlak0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>bassin</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>bezinkbak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>lage trafo</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>niet-bgt</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>open loods</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>opslagtank</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>overkapping</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>windturbine</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>3500</MinScaleDenominator>
-					<MaxScaleDenominator>0</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<MinScaleDenominator>0</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.90</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_achter0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_voor0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>tram0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>tram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.2</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>tram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">2</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_achter0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_voor0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_achter_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#787878</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#787878</CssParameter>
-							<CssParameter name="stroke-width">3.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_voor_0</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#DFDFDF</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer><Name>standplaats</Name><UserStyle><FeatureTypeStyle><Rule><MaxScaleDenominator>3500</MaxScaleDenominator><PolygonSymbolizer><Fill><CssParameter name="fill">#dbdbdb</CssParameter></Fill><Stroke><CssParameter name="stroke">#afafaf</CssParameter><CssParameter name="stroke-width">1</CssParameter></Stroke></PolygonSymbolizer></Rule></FeatureTypeStyle></UserStyle></NamedLayer>
-	<NamedLayer><Name>ligplaats</Name><UserStyle><FeatureTypeStyle><Rule><MaxScaleDenominator>3500</MaxScaleDenominator><PolygonSymbolizer><Fill><CssParameter name="fill">#dbdbdb</CssParameter></Fill><Stroke><CssParameter name="stroke">#afafaf</CssParameter><CssParameter name="stroke-width">1</CssParameter></Stroke></PolygonSymbolizer></Rule></FeatureTypeStyle></UserStyle></NamedLayer>
-	<NamedLayer>
-		<Name>wegdeel_vlak_tunnel</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-							<CssParameter name="fill-opacity">0.30</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>terreindeel_vlak1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>erf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>zand</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>onverhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>houtwal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>rietland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>2000</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F0F0F0</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#F0F0F0</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>erf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>zand</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>onverhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>houtwal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>rietland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F0F0F0</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>gesloten verharding</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>half verhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>perron</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>open verharding</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>strekdam</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#FFFFFF</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>groenvoorziening</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>struiken</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>grasland overig</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>grasland agrarisch</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#EDECE9</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>kwelder</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>oever</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F0F0F0</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#F0F0F0</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#EDECE9</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#EDECE9</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>berm_achter_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>gesloten verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>half verhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FBFBFB</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#FBFBFB</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>groenvoorziening</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>onverhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#EDECE9</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#EDECE9</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>berm_voor_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>gesloten verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>half verhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FBFBFB</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>groenvoorziening</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>onverhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#EDECE9</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_achter_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_voor_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetganers_achter_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetgangers_voor_1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F6F6F4</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>gebouw_vlak1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>bassin</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>bezinkbak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>lage trafo</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>niet-bgt</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>open loods</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>opslagtank</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>windturbine</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>3500</MinScaleDenominator>
-					<MaxScaleDenominator>0</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>overkapping</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-							<CssParameter name="fill-opacity">0.5</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<MinScaleDenominator>0</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.90</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>inrichtingselement_vlak1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>steiger</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F6F6F4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>sluis</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>gemaal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>stuw</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>muur</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E6E5E0</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_achter1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">2</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_voor1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>tram1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>tram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.2</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>tram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">2</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_achter1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_voor1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_achter1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#787878</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#787878</CssParameter>
-							<CssParameter name="stroke-width">3.2</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_voor1</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#DFDFDF</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>terreindeel_vlak2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>erf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>zand</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>onverhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>houtwal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>duin</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>rietland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>2000</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F0F0F0</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#F0F0F0</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>erf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>zand</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>onverhard</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>houtwal</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>duin</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>rietland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F0F0F0</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-							<ogc:Literal>gesloten verharding</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-							<ogc:Literal>perron</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-							<ogc:Literal>transitie</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-							<ogc:Literal>strekdam</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F5F4F2</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>oever</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>kwelder</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F0F0F0</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#F0F0F0</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>berm_achter_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>gesloten verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>half verhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FBFBFB</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#FBFBFB</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>groenvoorziening</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>onverhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#EDECE9</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#EDECE9</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>berm_voor_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>gesloten verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>half verhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>open verharding</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>transitie</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FBFBFB</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:And>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>berm</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:Or>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>groenvoorziening</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-								<ogc:PropertyIsEqualTo>
-									<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-									<ogc:Literal>onverhard</ogc:Literal>
-								</ogc:PropertyIsEqualTo>
-							</ogc:Or>
-						</ogc:And>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#EDECE9</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_achter_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1.80</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_voor_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetgangers_achter_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetgangers_voor_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F6F6F4</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>gebouw_vlak2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>bassin</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>bezinkbak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>lage trafo</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>niet-bgt</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>open loods</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>opslagtank</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>windturbine</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>3500</MinScaleDenominator>
-					<MaxScaleDenominator>0</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>overkapping</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-							<CssParameter name="fill-opacity">0.5</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<MinScaleDenominator>0</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.90</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>inrichtingselement_vlak2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>steiger</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F6F6F4</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>muur</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E6E5E0</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_achter2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_voor2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_achter2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>trein_voor2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>trein</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.4</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_achter_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#787878</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#787878</CssParameter>
-							<CssParameter name="stroke-width">3.2</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_voor_2</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#DFDFDF</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>terreindeel_vlak3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_fysiekvoorkomen</ogc:PropertyName>
-							<ogc:Literal>perron</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_achter_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1.80</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>rijbanen_voor_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>fietspad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>inrit</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>OV-baan</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>overweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan autoweg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan lokale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>rijbaan regionale weg</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>baan voor vliegverkeer</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>parkeervlak</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#FFFFFF</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetganers_achter_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#C9C7C2</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">1</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>voetgangers_voor_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>ruiterpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetgangersgebied</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>voetpad op trap</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>woonerf</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-								<ogc:Literal>verkeerseiland</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#F6F6F4</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>gebouw_vlak3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:Or>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>niet-bgt</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-							<ogc:PropertyIsEqualTo>
-								<ogc:PropertyName>bgt_type</ogc:PropertyName>
-								<ogc:Literal>transitie</ogc:Literal>
-							</ogc:PropertyIsEqualTo>
-						</ogc:Or>
-					</ogc:Filter>
-					<MinScaleDenominator>0</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>overkapping</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-							<CssParameter name="fill-opacity">0.5</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-				<Rule>
-					<MinScaleDenominator>0</MinScaleDenominator>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.90</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_achter3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>metro_voor3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">1.3</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>sneltram</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>2000</MaxScaleDenominator>
-					<LineSymbolizer>
-						<Stroke>
-							<CssParameter name="stroke">#ACACAC</CssParameter>
-							<CssParameter name="stroke-width">2.5</CssParameter>
-						</Stroke>
-					</LineSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_achter_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#787878</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#787878</CssParameter>
-							<CssParameter name="stroke-width">3.2</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>snelweg_voor_3</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_functie</ogc:PropertyName>
-							<ogc:Literal>rijbaan autosnelweg</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#DFDFDF</CssParameter>
-						</Fill>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
-	<NamedLayer>
-		<Name>gebouw_vlak4</Name>
-		<UserStyle>
-			<FeatureTypeStyle>
-				<Rule>
-					<ogc:Filter>
-						<ogc:PropertyIsEqualTo>
-							<ogc:PropertyName>bgt_type</ogc:PropertyName>
-							<ogc:Literal>overkapping</ogc:Literal>
-						</ogc:PropertyIsEqualTo>
-					</ogc:Filter>
-					<MaxScaleDenominator>3500</MaxScaleDenominator>
-					<PolygonSymbolizer>
-						<Fill>
-							<CssParameter name="fill">#E4E3DF</CssParameter>
-							<CssParameter name="fill-opacity">0.5</CssParameter>
-						</Fill>
-						<Stroke>
-							<CssParameter name="stroke">#C9C7C2</CssParameter>
-							<CssParameter name="stroke-width">0.5</CssParameter>
-						</Stroke>
-					</PolygonSymbolizer>
-				</Rule>
-			</FeatureTypeStyle>
-		</UserStyle>
-	</NamedLayer>
+<StyledLayerDescriptor
+    version="1.0.0"
+    xmlns="http://www.opengis.net/sld"
+    xmlns:gml="http://www.opengis.net/gml"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+    <NamedLayer>
+        <Name>waterdeel_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#BEBEBE</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#BEBEBE</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>ondersteunendewaterdelen_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F0F0F0</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>begroeideterreindelen_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>rietland</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>duin</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>houtwal</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F0F0F0</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>groenvoorziening</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>grasland overig</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>grasland agrarisch</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>struiken</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#EDECE9</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#EDECE9</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                            <ogc:Literal>kwelder</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F0F0F0</CssParameter>
+                            <CssParameter name="stroke-width">0.1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>loofbos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gemengd bos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>bouwland</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>moeras</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>fruitteelt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>boomteelt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>naaldbos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#DCDCDC</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#DCDCDC</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                            <ogc:Literal>heide</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F0F0F0</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>onbegroeideterreindelen_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>erf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>zand</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F0F0F0</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>erf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>zand</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gesloten verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>half verhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>perron</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>open verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>strekdam</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>overbruggingsdelen_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>berm_achter_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FBFBFB</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FBFBFB</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>berm_voor_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>open verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gesloten verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>half verhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FBFBFB</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>groenvoorziening</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#EDECE9</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_achter_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>fietspad</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>inrit</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>OV-baan</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>overweg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan autoweg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan lokale weg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan regionale weg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>overweg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>parkeervlak</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_voor_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>fietspad</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>inrit</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>OV-baan</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>overweg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan autoweg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan lokale weg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan regionale weg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>parkeervlak</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                            <ogc:Literal>baan voor vliegverkeer</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#DEDCD9</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_achter_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>ruiterpad</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>voetpad</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>voetgangersgebied</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>voetpad op trap</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>woonerf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_voor_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>ruiterpad</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>voetpad</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>voetgangersgebied</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>voetpad op trap</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>woonerf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F6F6F4</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>inrichtingselement_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>hoogspanningsmast</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>sluis</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>gemaal</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>stuw</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>perron</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>strekdam</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                            <ogc:Literal>steiger</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F6F6F4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>scheiding_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E6E5E0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>gebouw_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>lage trafo</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>niet-bgt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>open loods</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>opslagtank</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>overkapping</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>windturbine</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E4E3DF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>bassin</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>bezinkbak</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#BEBEBE</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">2</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>panden_vlak0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E4E3DF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.9</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_achter0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_voor0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>tram0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.2</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">2</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_achter0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_voor0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_achter_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#787878</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#787878</CssParameter>
+                            <CssParameter name="stroke-width">3.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_voor_0</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#DFDFDF</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>ligplaats</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#dbdbdb</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#afafaf</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>standplaats</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#dbdbdb</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#afafaf</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>wegdeel_vlak_tunnel</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan autoweg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan lokale weg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                                <ogc:Literal>rijbaan regionale weg</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                            <CssParameter name="fill-opacity">0.30</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>begroeideterreindelen_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>rietland</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>duin</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>houtwal</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F0F0F0</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>groenvoorziening</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>grasland overig</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>grasland agrarisch</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>struiken</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#EDECE9</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#EDECE9</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                            <ogc:Literal>kwelder</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F0F0F0</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>loofbos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gemengd bos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>bouwland</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>moeras</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>fruitteelt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>boomteelt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>naaldbos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#DCDCDC</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#DCDCDC</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                            <ogc:Literal>heide</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F0F0F0</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>onbegroeideterreindelen_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>erf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>zand</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F0F0F0</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>erf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>zand</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gesloten verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>half verhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>perron</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>open verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>strekdam</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>overbruggingsdelen_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>berm_achter_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FBFBFB</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FBFBFB</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>berm_voor_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gesloten verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>half verhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>open verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FBFBFB</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>groenvoorziening</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#EDECE9</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_achter_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_voor_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_achter_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_voor_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F6F6F4</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>inrichtingselement_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>hoogspanningsmast</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>sluis</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>gemaal</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>stuw</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>perron</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>strekdam</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                            <ogc:Literal>steiger</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F6F6F4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>scheiding_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E6E5E0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>gebouw_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>lage trafo</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>niet-bgt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>open loods</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>opslagtank</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>overkapping</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>windturbine</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E4E3DF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>bassin</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>bezinkbak</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#BEBEBE</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">2</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>panden_vlak1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E4E3DF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.9</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_achter1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_voor1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>tram1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.2</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">2</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_achter1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_voor1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_functie</ogc:PropertyName>
+                            <ogc:Literal>trein</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_achter1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#787878</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#787878</CssParameter>
+                            <CssParameter name="stroke-width">3.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_voor1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#DFDFDF</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>begroeideterreindelen_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>rietland</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>duin</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>houtwal</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F0F0F0</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>groenvoorziening</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>grasland overig</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>grasland agrarisch</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>struiken</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#EDECE9</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#EDECE9</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                            <ogc:Literal>kwelder</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F0F0F0</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>loofbos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gemengd bos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>bouwland</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>moeras</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>fruitteelt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>boomteelt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>naaldbos</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#DCDCDC</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#DCDCDC</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                            <ogc:Literal>heide</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F0F0F0</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>onbegroeideterreindelen_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>erf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>zand</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#F0F0F0</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>erf</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>zand</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F0F0F0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gesloten verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>half verhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>perron</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>open verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>strekdam</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>overbruggingsdelen_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>berm_achter_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FBFBFB</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FBFBFB</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>berm_voor_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>gesloten verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>half verhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>open verharding</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FBFBFB</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>groenvoorziening</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_fysiek_voorkomen</ogc:PropertyName>
+                                <ogc:Literal>onverhard</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#EDECE9</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_achter_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1.80</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_voor_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_achter_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_voor_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F6F6F4</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>inrichtingselement_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>hoogspanningsmast</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>sluis</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>gemaal</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>stuw</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>perron</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>strekdam</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                            <ogc:Literal>steiger</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F6F6F4</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>scheiding_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E6E5E0</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>gebouw_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>lage trafo</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>niet-bgt</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>open loods</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>opslagtank</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>overkapping</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>transitie</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>windturbine</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E4E3DF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+                <Rule>
+                    <ogc:Filter>
+                        <ogc:Or>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>bassin</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>bgt_type</ogc:PropertyName>
+                                <ogc:Literal>bezinkbak</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:Or>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#BEBEBE</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">2</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>panden_vlak2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E4E3DF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.9</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_achter2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_voor2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_achter2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_voor2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_achter_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#787878</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#787878</CssParameter>
+                            <CssParameter name="stroke-width">3.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_voor_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#DFDFDF</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_achter_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1.80</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>rijbanen_voor_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_achter_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#C9C7C2</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>voetgangers_voor_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#F6F6F4</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>inrichtingselement_vlak3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#FFFFFF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#FFFFFF</CssParameter>
+                            <CssParameter name="stroke-width">1</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>gebouw_vlak3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E4E3DF</CssParameter>
+                            <CssParameter name="fill-opacity">0.5</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>panden_vlak3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E4E3DF</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.9</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_achter3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_voor3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_achter_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#787878</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#787878</CssParameter>
+                            <CssParameter name="stroke-width">3.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>snelweg_voor_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#DFDFDF</CssParameter>
+                        </Fill>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>gebouw_vlak4</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PolygonSymbolizer>
+                        <Fill>
+                            <CssParameter name="fill">#E4E3DF</CssParameter>
+                            <CssParameter name="fill-opacity">0.5</CssParameter>
+                        </Fill>
+                        <Stroke>
+                            <CssParameter name="stroke">#C9C7C2</CssParameter>
+                            <CssParameter name="stroke-width">0.5</CssParameter>
+                        </Stroke>
+                    </PolygonSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_3</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                            <CssParameter name="stroke-dasharray">5 5 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                            <CssParameter name="stroke-dasharray">7 7 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                            <CssParameter name="stroke-dasharray">5 5 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                            <CssParameter name="stroke-dasharray">7 7 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_2</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                            <CssParameter name="stroke-dasharray">8 8 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                            <CssParameter name="stroke-dasharray">8 8 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_achter_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>metro_voor_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">1.3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">2.5</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>tram_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">1.2</CssParameter>
+                            <CssParameter name="stroke-dasharray">4 4 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">2</CssParameter>
+                            <CssParameter name="stroke-dasharray">4 4 </CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_achter_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+    <NamedLayer>
+        <Name>trein_voor_1</Name>
+        <UserStyle>
+            <FeatureTypeStyle>
+                <Rule>
+                    <MinScaleDenominator>2500</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">1.4</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+                <Rule>
+                    <MaxScaleDenominator>2500</MaxScaleDenominator>
+                    <LineSymbolizer>
+                        <Stroke>
+                            <CssParameter name="stroke">#ACACAC</CssParameter>
+                            <CssParameter name="stroke-opacity">0.5</CssParameter>
+                            <CssParameter name="stroke-width">3</CssParameter>
+                        </Stroke>
+                    </LineSymbolizer>
+                </Rule>
+            </FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
 </StyledLayerDescriptor>

--- a/sld/kbk10_light.xml
+++ b/sld/kbk10_light.xml
@@ -5,7 +5,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -21,7 +21,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -37,7 +37,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -57,7 +57,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -73,7 +73,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -89,7 +89,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -105,7 +105,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -121,7 +121,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -137,7 +137,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -153,7 +153,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -169,7 +169,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -185,7 +185,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -201,7 +201,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -217,7 +217,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -233,7 +233,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -249,7 +249,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -265,7 +265,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -281,7 +281,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -297,7 +297,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -313,7 +313,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -329,7 +329,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -345,7 +345,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -361,7 +361,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -383,7 +383,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -405,7 +405,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -421,7 +421,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>10000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -441,7 +441,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -457,7 +457,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -474,7 +474,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -491,7 +491,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -509,7 +509,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -526,7 +526,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -543,7 +543,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -560,7 +560,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -576,7 +576,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -593,8 +593,8 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>8000</MaxScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
+          <MaxScaleDenominator>10000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -610,11 +610,12 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
-              <CssParameter name="stroke-width">0</CssParameter>
+              <CssParameter name="stroke">#BCB7D2</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
@@ -626,11 +627,12 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
-              <CssParameter name="stroke-width">0</CssParameter>
+              <CssParameter name="stroke">#BCB7D2</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
@@ -642,7 +644,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -659,7 +661,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -676,7 +678,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -692,7 +694,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -709,7 +711,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -725,7 +727,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -742,8 +744,8 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>8000</MaxScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
+          <MaxScaleDenominator>10000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -759,7 +761,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -775,7 +777,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -792,7 +794,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -808,7 +810,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -824,7 +826,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -841,7 +843,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -858,7 +860,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>8000</MinScaleDenominator>
+          <MinScaleDenominator>10000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -868,8 +870,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>8000</MaxScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
+          <MaxScaleDenominator>10000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -885,7 +887,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>8000</MinScaleDenominator>
+          <MinScaleDenominator>10000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -895,8 +897,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>8000</MaxScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
+          <MaxScaleDenominator>10000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#EAEAAE</CssParameter>

--- a/sld/kbk10_zw.xml
+++ b/sld/kbk10_zw.xml
@@ -5,7 +5,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -21,7 +21,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -37,7 +37,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -57,7 +57,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -73,7 +73,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -89,7 +89,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -105,7 +105,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -121,7 +121,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -137,7 +137,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -153,7 +153,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -169,7 +169,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -185,7 +185,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -201,7 +201,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -217,7 +217,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -233,7 +233,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -249,7 +249,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -265,7 +265,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -281,7 +281,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -297,7 +297,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -313,7 +313,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -329,7 +329,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -345,7 +345,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -361,7 +361,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -383,7 +383,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -405,7 +405,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -421,8 +421,8 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>8000</MaxScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
+          <MaxScaleDenominator>10000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F0F0F0</CssParameter>
@@ -441,7 +441,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
@@ -457,7 +457,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -474,7 +474,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -491,7 +491,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -509,7 +509,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -526,7 +526,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -543,7 +543,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -560,7 +560,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -576,7 +576,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -593,8 +593,8 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>8000</MaxScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
+          <MaxScaleDenominator>10000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -610,7 +610,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -627,7 +627,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -644,11 +644,12 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
-              <CssParameter name="stroke-width">0</CssParameter>
+              <CssParameter name="stroke">#ACACAC</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
@@ -660,11 +661,12 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
-              <CssParameter name="stroke-width">0</CssParameter>
+              <CssParameter name="stroke">#ACACAC</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
@@ -676,7 +678,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -692,7 +694,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -709,7 +711,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -725,7 +727,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -742,8 +744,8 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>8000</MaxScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
+          <MaxScaleDenominator>10000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -759,7 +761,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -775,7 +777,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -792,7 +794,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -808,7 +810,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -824,7 +826,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -841,7 +843,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -858,7 +860,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>8000</MinScaleDenominator>
+          <MinScaleDenominator>10000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -868,8 +870,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>8000</MaxScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
+          <MaxScaleDenominator>10000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#787878</CssParameter>
@@ -885,7 +887,7 @@
     <UserStyle>
       <FeatureTypeStyle>
         <Rule>
-          <MinScaleDenominator>8000</MinScaleDenominator>
+          <MinScaleDenominator>10000</MinScaleDenominator>
           <MaxScaleDenominator>20000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
@@ -895,8 +897,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>3500</MinScaleDenominator>
-          <MaxScaleDenominator>8000</MaxScaleDenominator>
+          <MinScaleDenominator>5000</MinScaleDenominator>
+          <MaxScaleDenominator>10000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#DFDFDF</CssParameter>

--- a/sld/kbk50_light.xml
+++ b/sld/kbk50_light.xml
@@ -6,7 +6,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#B2CBD9</CssParameter>
@@ -22,7 +22,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#E5EBD8</CssParameter>
@@ -38,7 +38,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F5F4F2</CssParameter>
@@ -54,13 +54,11 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F5F4F2</CssParameter>
             </Fill>
-          </PolygonSymbolizer>
-          <PolygonSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#F5F4F2</CssParameter>
               <CssParameter name="stroke-width">0.50</CssParameter>
@@ -76,7 +74,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D2E3BA</CssParameter>
@@ -92,10 +90,39 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#E5EBD8</CssParameter>
+            </Fill>
+          </PolygonSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+  <NamedLayer>
+    <Name>TRN_kassengebied</Name>
+    <UserStyle>
+      <FeatureTypeStyle>
+        <Rule>
+          <MinScaleDenominator>20000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#D9D9D4</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#D9D9D4</CssParameter>
+              <CssParameter name="stroke-width">0.70</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+        </Rule>
+        <Rule>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#D9D9D4</CssParameter>
             </Fill>
           </PolygonSymbolizer>
         </Rule>
@@ -108,7 +135,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D9D9D4</CssParameter>
@@ -120,8 +147,8 @@
           </PolygonSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D9D9D4</CssParameter>
@@ -137,7 +164,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D9D9D4</CssParameter>
@@ -153,21 +180,11 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B2CBD9</CssParameter>
-              <CssParameter name="stroke-width">0.10</CssParameter>
-            </Stroke>
-          </LineSymbolizer>
-        </Rule>
-        <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
-          <LineSymbolizer>
-            <Stroke>
-              <CssParameter name="stroke">#B2CBD9</CssParameter>
-              <CssParameter name="stroke-width">0.10</CssParameter>
+              <CssParameter name="stroke-width">0.2</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
@@ -180,11 +197,11 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B2CBD9</CssParameter>
-              <CssParameter name="stroke-width">0.20</CssParameter>
+              <CssParameter name="stroke-width">0.1</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
@@ -197,7 +214,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -207,8 +224,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>75000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -226,7 +243,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -236,8 +253,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -247,8 +264,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -266,7 +283,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -276,8 +293,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -287,8 +304,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -306,7 +323,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -316,8 +333,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -327,8 +344,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -338,23 +355,13 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>100000</MinScaleDenominator>
-          <MaxScaleDenominator>200000</MaxScaleDenominator>
+          <MinScaleDenominator>160000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
               <CssParameter name="stroke-width">3</CssParameter>
               <CssParameter name="stroke-dasharray">1 3</CssParameter>
-            </Stroke>
-          </LineSymbolizer>
-        </Rule>
-        <Rule>
-          <MinScaleDenominator>200000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
-          <LineSymbolizer>
-            <Stroke>
-              <CssParameter name="stroke">#B4B4B4</CssParameter>
-              <CssParameter name="stroke-width">3</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
@@ -367,7 +374,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -376,8 +383,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -386,8 +393,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>200000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -396,8 +403,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>200000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MinScaleDenominator>160000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -414,7 +421,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#EAEAAE</CssParameter>
@@ -423,8 +430,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#EAEAAE</CssParameter>
@@ -433,8 +440,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#EAEAAE</CssParameter>
@@ -443,8 +450,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>100000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MinScaleDenominator>160000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#EAEAAE</CssParameter>
@@ -461,7 +468,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -470,8 +477,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>75000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#D9D9D4</CssParameter>
@@ -488,7 +495,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -497,8 +504,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -507,8 +514,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -525,7 +532,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -534,8 +541,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -552,7 +559,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -561,12 +568,12 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>75000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
-              <CssParameter name="stroke-width">0.4</CssParameter>
+              <CssParameter name="stroke-width">0.75</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
@@ -616,7 +623,17 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#FBFBFB</CssParameter>
+              <CssParameter name="stroke-width">4</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+        <Rule>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -625,8 +642,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>200000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -635,8 +652,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>200000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MinScaleDenominator>160000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -653,7 +670,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -670,7 +687,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -687,7 +704,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -704,7 +721,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -721,7 +738,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -738,7 +755,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -755,7 +772,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -772,7 +789,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -789,7 +806,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -806,7 +823,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BCB7D2</CssParameter>
@@ -823,7 +840,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -832,8 +849,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -842,8 +859,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -852,8 +869,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>100000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MinScaleDenominator>160000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -870,7 +887,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#EAEAAE</CssParameter>
@@ -879,8 +896,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#EAEAAE</CssParameter>
@@ -889,8 +906,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#EAEAAE</CssParameter>
@@ -899,8 +916,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>100000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MinScaleDenominator>160000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#EAEAAE</CssParameter>
@@ -917,7 +934,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>

--- a/sld/kbk50_zw.xml
+++ b/sld/kbk50_zw.xml
@@ -6,7 +6,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#BEBEBE</CssParameter>
@@ -22,7 +22,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F5F4F2</CssParameter>
@@ -38,7 +38,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F5F4F2</CssParameter>
@@ -54,7 +54,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#D3D2CF</CssParameter>
@@ -74,7 +74,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill"> #DCDCDC</CssParameter>
@@ -90,10 +90,39 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#F5F4F2</CssParameter>
+            </Fill>
+          </PolygonSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+    <NamedLayer>
+    <Name>TRN_kassengebied</Name>
+    <UserStyle>
+      <FeatureTypeStyle>
+        <Rule>
+          <MinScaleDenominator>20000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#E4E3DF</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#E4E3DF</CssParameter>
+              <CssParameter name="stroke-width">0.70</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+        </Rule>
+        <Rule>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#E4E3DF</CssParameter>
             </Fill>
           </PolygonSymbolizer>
         </Rule>
@@ -106,7 +135,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#E4E3DF</CssParameter>
@@ -118,8 +147,8 @@
           </PolygonSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#E4E3DF</CssParameter>
@@ -135,7 +164,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <PolygonSymbolizer>
             <Fill>
               <CssParameter name="fill">#E8E8E8</CssParameter>
@@ -151,11 +180,11 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BEBEBE</CssParameter>
-              <CssParameter name="stroke-width">0.1</CssParameter>
+              <CssParameter name="stroke-width">0.2</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
@@ -168,11 +197,11 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#BEBEBE</CssParameter>
-              <CssParameter name="stroke-width">0.20</CssParameter>
+              <CssParameter name="stroke-width">0.1</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
@@ -185,7 +214,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -195,8 +224,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>75000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -214,7 +243,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -224,8 +253,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -235,8 +264,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -254,7 +283,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -264,8 +293,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -275,8 +304,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -294,55 +323,45 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#C8C8C8</CssParameter>
               <CssParameter name="stroke-width">7</CssParameter>
-              <CssParameter name="stroke-dasharray">4 3 </CssParameter>
+              <CssParameter name="stroke-dasharray">4 3</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#C8C8C8</CssParameter>
               <CssParameter name="stroke-width">6</CssParameter>
-              <CssParameter name="stroke-dasharray">3 3 </CssParameter>
+              <CssParameter name="stroke-dasharray">3 3</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#C8C8C8</CssParameter>
               <CssParameter name="stroke-width">4.5</CssParameter>
-              <CssParameter name="stroke-dasharray">2 3 </CssParameter>
+              <CssParameter name="stroke-dasharray">2 3</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>100000</MinScaleDenominator>
-          <MaxScaleDenominator>200000</MaxScaleDenominator>
+          <MinScaleDenominator>160000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#C8C8C8</CssParameter>
               <CssParameter name="stroke-width">3</CssParameter>
-              <CssParameter name="stroke-dasharray">1 3 </CssParameter>
-            </Stroke>
-          </LineSymbolizer>
-        </Rule>
-        <Rule>
-          <MinScaleDenominator>200000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
-          <LineSymbolizer>
-            <Stroke>
-              <CssParameter name="stroke">#C8C8C8</CssParameter>
-              <CssParameter name="stroke-width">3</CssParameter>
+              <CssParameter name="stroke-dasharray">1 3</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
@@ -355,7 +374,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FFFFFF</CssParameter>
@@ -364,8 +383,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FFFFFF</CssParameter>
@@ -374,8 +393,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>200000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FFFFFF</CssParameter>
@@ -384,8 +403,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>200000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MinScaleDenominator>160000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -402,7 +421,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#DFDFDF</CssParameter>
@@ -411,8 +430,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#DFDFDF</CssParameter>
@@ -421,8 +440,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#DFDFDF</CssParameter>
@@ -431,8 +450,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>100000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MinScaleDenominator>160000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
                 <CssParameter name="stroke">#DFDFDF</CssParameter>
@@ -449,7 +468,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -458,8 +477,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>75000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#E4E3DF</CssParameter>
@@ -476,7 +495,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -485,8 +504,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -495,8 +514,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -513,7 +532,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -522,8 +541,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#B4B4B4</CssParameter>
@@ -540,7 +559,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FFFFFF</CssParameter>
@@ -549,8 +568,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>75000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FFFFFF</CssParameter>
@@ -567,7 +586,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -576,8 +595,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -586,8 +605,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FBFBFB</CssParameter>
@@ -604,7 +623,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FFFFFF</CssParameter>
@@ -613,8 +632,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FFFFFF</CssParameter>
@@ -623,8 +642,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>200000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FFFFFF</CssParameter>
@@ -633,8 +652,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>200000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MinScaleDenominator>160000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#FFFFFF</CssParameter>
@@ -651,7 +670,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -668,7 +687,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -685,7 +704,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -702,7 +721,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -719,10 +738,11 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
-              <CssParameter name="stroke-width">0</CssParameter>
+              <CssParameter name="stroke">#ACACAC</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
             </Stroke>
           </LineSymbolizer>
         </Rule>
@@ -735,7 +755,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -752,7 +772,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -769,7 +789,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -786,7 +806,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -803,7 +823,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#ACACAC</CssParameter>
@@ -820,7 +840,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#C8C8C8</CssParameter>
@@ -829,8 +849,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#C8C8C8</CssParameter>
@@ -839,8 +859,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#C8C8C8</CssParameter>
@@ -849,8 +869,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>100000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MinScaleDenominator>160000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#C8C8C8</CssParameter>
@@ -867,7 +887,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>25000</MaxScaleDenominator>
+          <MaxScaleDenominator>40000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#DFDFDF</CssParameter>
@@ -876,8 +896,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>25000</MinScaleDenominator>
-          <MaxScaleDenominator>50000</MaxScaleDenominator>
+          <MinScaleDenominator>40000</MinScaleDenominator>
+          <MaxScaleDenominator>80000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#DFDFDF</CssParameter>
@@ -886,8 +906,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>50000</MinScaleDenominator>
-          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <MinScaleDenominator>80000</MinScaleDenominator>
+          <MaxScaleDenominator>160000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#DFDFDF</CssParameter>
@@ -896,8 +916,8 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <MinScaleDenominator>100000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MinScaleDenominator>160000</MinScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke">#DFDFDF</CssParameter>
@@ -914,7 +934,7 @@
       <FeatureTypeStyle>
         <Rule>
           <MinScaleDenominator>20000</MinScaleDenominator>
-          <MaxScaleDenominator>300000</MaxScaleDenominator>
+          <MaxScaleDenominator>320000</MaxScaleDenominator>
           <LineSymbolizer>
             <Stroke>
               <CssParameter name="stroke-width">0</CssParameter>


### PR DESCRIPTION
- similar zoom levels show same information irrespective of projection
- widths of lines and dash arrays aligned between different visualisations
- SLDs adjusted for new layers because of migration to refDB
- filters adjusted to new column names in refDB
- SQL queries only select required columns for visualisation instead of selecting all columns