### PR TITLE
Upgrade setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update -y \
         wget \
     && apt-get clean
 
+RUN python3 -m pip install --upgrade pip setuptools
 
 # Enable these Apache modules
 RUN a2enmod actions cgid headers rewrite


### PR DESCRIPTION
The setuptools version in the python3-pip package is outdated and has a vulnerability.