### PR TITLE
Bump aiosignal to 1.4.0 for compatibility with aiohttp 3.12

### DIFF
--- a/jwtproxy/requirements.txt
+++ b/jwtproxy/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.12.14
-aiosignal==1.3.1
+aiosignal==1.4.0
 async-timeout==4.0.2
 attrs==22.1.0
 cffi==1.15.1
@@ -12,5 +12,5 @@ jwcrypto==1.5.6
 multidict==6.0.2
 pycparser==2.21
 wrapt==1.14.1
-yarl===1.12.0
+yarl===1.17.0
 opencensus-ext-azure==1.1.8

--- a/jwtproxy/requirements_dev.txt
+++ b/jwtproxy/requirements_dev.txt
@@ -11,5 +11,5 @@ six==1.16.0
 sniffio==1.3.0
 watchgod==0.8.2
 wrapt==1.14.1
-yarl==1.8.1
+yarl==1.17.0
 


### PR DESCRIPTION
aiosignal was incompatible with recently bumped version of aiohttp