### PR TITLE
Bump Ubuntu to 26.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:26.04
 LABEL maintainer="datapunt@amsterdam.nl"
 ARG DEBIAN_FRONTEND=noninteractive
 # build-time inputs

--- a/jwtproxy/Dockerfile.dev
+++ b/jwtproxy/Dockerfile.dev
@@ -5,7 +5,7 @@
 # For testing against the nginx-controller locally. A minikube setup can be used
 # in combination with manifest.yml
 
-FROM python:3.13-slim-bullseye
+FROM python:3.13-slim-trixie
 
 RUN apt-get update && apt-get install nginx -y
 COPY supervisord.conf /etc

--- a/jwtproxy/Dockerfile.prd
+++ b/jwtproxy/Dockerfile.prd
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bullseye
+FROM python:3.13-slim-trixie
 
 COPY supervisord.conf /etc
 


### PR DESCRIPTION
25.04 is nolonger supported.
The bug in Mapserver preventing us from going to 26 is fixed. So back to lts version.